### PR TITLE
feat: Add Quick Dose Buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ const AppContent = () => {
         addEvent, updateEvent, deleteEvent, clearAllEvents,
         addLabResult, updateLabResult, deleteLabResult, clearLabResults,
         addTemplate, deleteTemplate,
+        addQuickDose, deleteQuickDose,
+        quickDoses,
         processImportedData
     } = useAppData(showDialog);
 
@@ -350,6 +352,9 @@ const AppContent = () => {
                             onDeleteEvent={deleteEvent}
                             onSaveTemplate={addTemplate}
                             onDeleteTemplate={deleteTemplate}
+                            quickDoses={quickDoses}
+                            onAddQuickDose={addQuickDose}
+                            onDeleteQuickDose={deleteQuickDose}
                             groupedEvents={groupedEvents}
                             onEditEvent={handleEditEvent}
                         />
@@ -490,6 +495,9 @@ const AppContent = () => {
                 templates={doseTemplates}
                 onSaveTemplate={addTemplate}
                 onDeleteTemplate={deleteTemplate}
+                quickDoses={quickDoses}
+                onAddQuickDose={addQuickDose}
+                onDeleteQuickDose={deleteQuickDose}
             />
 
             <DisclaimerModal

--- a/src/components/DoseForm.tsx
+++ b/src/components/DoseForm.tsx
@@ -13,6 +13,7 @@ import OralFields from './dose_form/OralFields';
 import SublingualFields from './dose_form/SublingualFields';
 import GelFields from './dose_form/GelFields';
 import PatchFields from './dose_form/PatchFields';
+import QuickDoseButtons, { QuickDose } from './dose_form/QuickDoseButtons';
 
 export interface DoseTemplate {
     id: string;
@@ -126,10 +127,13 @@ interface DoseFormProps {
     templates: DoseTemplate[];
     onSaveTemplate: (template: DoseTemplate) => void;
     onDeleteTemplate: (id: string) => void;
+    quickDoses?: QuickDose[];
+    onAddQuickDose?: (dose: QuickDose) => void;
+    onDeleteQuickDose?: (id: string) => void;
     isInline?: boolean;
 }
 
-const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDelete, templates = [], onSaveTemplate, onDeleteTemplate, isInline = false }) => {
+const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDelete, templates = [], onSaveTemplate, onDeleteTemplate, quickDoses = [], onAddQuickDose, onDeleteQuickDose, isInline = false }) => {
     const { t, lang } = useTranslation();
     const { showDialog } = useDialog();
     const dateInputRef = useRef<HTMLInputElement>(null);
@@ -729,6 +733,17 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     lastEditedField={lastEditedField}
                                 />
                             )}
+                            {route === Route.injection && onAddQuickDose && onDeleteQuickDose && (
+                                <QuickDoseButtons
+                                    route={route}
+                                    ester={ester}
+                                    quickDoses={quickDoses}
+                                    currentDose={rawDose}
+                                    onSelectDose={(val) => handleRawChange(val.toFixed(3))}
+                                    onAddQuickDose={onAddQuickDose}
+                                    onDeleteQuickDose={onDeleteQuickDose}
+                                />
+                            )}
 
                             {route === Route.oral && (
                                 <OralFields
@@ -740,6 +755,17 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     isInitializing={isInitializingRef.current}
                                     route={route}
                                     lastEditedField={lastEditedField}
+                                />
+                            )}
+                            {route === Route.oral && onAddQuickDose && onDeleteQuickDose && (
+                                <QuickDoseButtons
+                                    route={route}
+                                    ester={ester}
+                                    quickDoses={quickDoses}
+                                    currentDose={rawDose}
+                                    onSelectDose={(val) => handleRawChange(val.toFixed(3))}
+                                    onAddQuickDose={onAddQuickDose}
+                                    onDeleteQuickDose={onDeleteQuickDose}
                                 />
                             )}
 
@@ -765,6 +791,17 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     lastEditedField={lastEditedField}
                                 />
                             )}
+                            {route === Route.sublingual && onAddQuickDose && onDeleteQuickDose && (
+                                <QuickDoseButtons
+                                    route={route}
+                                    ester={ester}
+                                    quickDoses={quickDoses}
+                                    currentDose={rawDose}
+                                    onSelectDose={(val) => handleRawChange(val.toFixed(3))}
+                                    onAddQuickDose={onAddQuickDose}
+                                    onDeleteQuickDose={onDeleteQuickDose}
+                                />
+                            )}
 
                             {route === Route.gel && (
                                 <GelFields
@@ -772,6 +809,17 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     setGelSite={setGelSite}
                                     e2Dose={e2Dose}
                                     onE2Change={handleE2Change}
+                                />
+                            )}
+                            {route === Route.gel && onAddQuickDose && onDeleteQuickDose && (
+                                <QuickDoseButtons
+                                    route={route}
+                                    ester={ester}
+                                    quickDoses={quickDoses}
+                                    currentDose={e2Dose}
+                                    onSelectDose={(val) => handleE2Change(val.toFixed(3))}
+                                    onAddQuickDose={onAddQuickDose}
+                                    onDeleteQuickDose={onDeleteQuickDose}
                                 />
                             )}
 
@@ -784,6 +832,24 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     rawDose={rawDose}
                                     onRawChange={handleRawChange}
                                     route={route}
+                                />
+                            )}
+                            {route === Route.patchApply && onAddQuickDose && onDeleteQuickDose && (
+                                <QuickDoseButtons
+                                    route={route}
+                                    ester={ester}
+                                    quickDoses={quickDoses}
+                                    currentDose={patchMode === 'rate' ? patchRate : rawDose}
+                                    onSelectDose={(val) => {
+                                        if (patchMode === 'rate') {
+                                            setPatchRate(val.toString());
+                                        } else {
+                                            handleRawChange(val.toFixed(3));
+                                        }
+                                    }}
+                                    onAddQuickDose={onAddQuickDose}
+                                    onDeleteQuickDose={onDeleteQuickDose}
+                                    unit={patchMode === 'rate' ? 'µg/d' : 'mg'}
                                 />
                             )}
                         </div>

--- a/src/components/DoseFormModal.tsx
+++ b/src/components/DoseFormModal.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import DoseForm, { DoseTemplate } from './DoseForm';
+import { QuickDose } from './dose_form/QuickDoseButtons';
 import { useEscape } from '../hooks/useEscape';
 
-export type { DoseTemplate };
+export type { DoseTemplate, QuickDose };
 
 interface DoseFormModalProps {
     isOpen: boolean;
@@ -13,6 +14,9 @@ interface DoseFormModalProps {
     templates?: DoseTemplate[];
     onSaveTemplate?: any;
     onDeleteTemplate?: any;
+    quickDoses?: QuickDose[];
+    onAddQuickDose?: (dose: QuickDose) => void;
+    onDeleteQuickDose?: (id: string) => void;
 }
 
 const DoseFormModal: React.FC<DoseFormModalProps> = ({
@@ -23,7 +27,10 @@ const DoseFormModal: React.FC<DoseFormModalProps> = ({
     onDelete,
     templates = [],
     onSaveTemplate,
-    onDeleteTemplate
+    onDeleteTemplate,
+    quickDoses = [],
+    onAddQuickDose,
+    onDeleteQuickDose
 }) => {
     const [isVisible, setIsVisible] = useState(false);
     const [isClosing, setIsClosing] = useState(false);
@@ -71,6 +78,9 @@ const DoseFormModal: React.FC<DoseFormModalProps> = ({
                     templates={templates}
                     onSaveTemplate={onSaveTemplate}
                     onDeleteTemplate={onDeleteTemplate}
+                    quickDoses={quickDoses}
+                    onAddQuickDose={onAddQuickDose}
+                    onDeleteQuickDose={onDeleteQuickDose}
                     isInline={false}
                 />
             </div>

--- a/src/components/dose_form/QuickDoseButtons.tsx
+++ b/src/components/dose_form/QuickDoseButtons.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Plus, X } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from '../../contexts/LanguageContext';
+import { useDialog } from '../../contexts/DialogContext';
+import { Route, Ester } from '../../../logic';
+
+export interface QuickDose {
+    id: string;
+    route: Route;
+    ester: Ester;
+    value: number;
+    createdAt: number;
+}
+
+interface QuickDoseButtonsProps {
+    route: Route;
+    ester: Ester;
+    quickDoses: QuickDose[];
+    currentDose: string;
+    onSelectDose: (value: number) => void;
+    onAddQuickDose: (dose: QuickDose) => void;
+    onDeleteQuickDose: (id: string) => void;
+    unit?: string;
+}
+
+const QuickDoseButtons: React.FC<QuickDoseButtonsProps> = ({
+    route,
+    ester,
+    quickDoses,
+    currentDose,
+    onSelectDose,
+    onAddQuickDose,
+    onDeleteQuickDose,
+    unit = 'mg'
+}) => {
+    const { t } = useTranslation();
+    const { showDialog } = useDialog();
+
+    // Filter quick doses for current route + ester combination
+    const filteredDoses = quickDoses
+        .filter(d => d.route === route && d.ester === ester)
+        .sort((a, b) => a.value - b.value);
+
+    const handleAdd = () => {
+        const val = parseFloat(currentDose);
+        if (!Number.isFinite(val) || val <= 0) {
+            showDialog('alert', t('quickdose.empty_input'));
+            return;
+        }
+
+        // Check for duplicate
+        const exists = filteredDoses.some(d => Math.abs(d.value - val) < 0.0001);
+        if (exists) return;
+
+        const newDose: QuickDose = {
+            id: uuidv4(),
+            route,
+            ester,
+            value: val,
+            createdAt: Date.now()
+        };
+        onAddQuickDose(newDose);
+    };
+
+    const handleDelete = (id: string) => {
+        showDialog('confirm', t('quickdose.delete_confirm'), () => {
+            onDeleteQuickDose(id);
+        });
+    };
+
+    const formatValue = (val: number): string => {
+        if (Number.isInteger(val)) return val.toString();
+        // Remove trailing zeros
+        const str = val.toFixed(3);
+        return str.replace(/\.?0+$/, '');
+    };
+
+    return (
+        <div className="flex flex-wrap items-center gap-1.5 mt-2">
+            {filteredDoses.map(dose => (
+                <div key={dose.id} className="group relative">
+                    <button
+                        type="button"
+                        onClick={() => onSelectDose(dose.value)}
+                        className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold rounded-[var(--radius-full)] border transition-all duration-200
+                            bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)]
+                            border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)]
+                            text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]
+                            hover:bg-[var(--color-m3-primary-container)] dark:hover:bg-teal-900/30
+                            hover:border-[var(--color-m3-primary)] dark:hover:border-teal-500
+                            hover:text-[var(--color-m3-primary)] dark:hover:text-teal-400
+                            active:scale-95"
+                    >
+                        {formatValue(dose.value)} {unit}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); handleDelete(dose.id); }}
+                        className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full flex items-center justify-center
+                            bg-red-100 dark:bg-red-900/40 text-red-500 dark:text-red-400
+                            opacity-0 group-hover:opacity-100 transition-opacity duration-150
+                            hover:bg-red-200 dark:hover:bg-red-900/60"
+                    >
+                        <X size={10} strokeWidth={3} />
+                    </button>
+                </div>
+            ))}
+            <button
+                type="button"
+                onClick={handleAdd}
+                className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-bold rounded-[var(--radius-full)] border border-dashed transition-all duration-200
+                    border-[var(--color-m3-outline)] dark:border-[var(--color-m3-dark-outline)]
+                    text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)]
+                    hover:border-[var(--color-m3-primary)] dark:hover:border-teal-400
+                    hover:text-[var(--color-m3-primary)] dark:hover:text-teal-400
+                    hover:bg-[var(--color-m3-primary-container)]/30 dark:hover:bg-teal-900/20
+                    active:scale-95"
+                title={t('quickdose.add')}
+            >
+                <Plus size={14} strokeWidth={2.5} />
+            </button>
+        </div>
+    );
+};
+
+export default QuickDoseButtons;

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -14,6 +14,14 @@ export interface DoseTemplate {
     createdAt: number;
 }
 
+export interface QuickDose {
+    id: string;
+    route: Route;
+    ester: Ester;
+    value: number;
+    createdAt: number;
+}
+
 export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: string, onConfirm?: () => void) => void) => {
     const { t, lang } = useTranslation();
 
@@ -34,6 +42,10 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
         const saved = localStorage.getItem('hrt-dose-templates');
         return saved ? JSON.parse(saved) : [];
     });
+    const [quickDoses, setQuickDoses] = useState<QuickDose[]>(() => {
+        const saved = localStorage.getItem('hrt-quick-doses');
+        return saved ? JSON.parse(saved) : [];
+    });
 
     const [simulation, setSimulation] = useState<SimulationResult | null>(null);
     const [currentTime, setCurrentTime] = useState(new Date());
@@ -43,6 +55,7 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
     useEffect(() => { localStorage.setItem('hrt-weight', weight.toString()); }, [weight]);
     useEffect(() => { localStorage.setItem('hrt-lab-results', JSON.stringify(labResults)); }, [labResults]);
     useEffect(() => { localStorage.setItem('hrt-dose-templates', JSON.stringify(doseTemplates)); }, [doseTemplates]);
+    useEffect(() => { localStorage.setItem('hrt-quick-doses', JSON.stringify(quickDoses)); }, [quickDoses]);
 
     useEffect(() => {
         const timer = setInterval(() => setCurrentTime(new Date()), 60000);
@@ -137,6 +150,9 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
 
     const addTemplate = (template: DoseTemplate) => setDoseTemplates(prev => [...prev, template]);
     const deleteTemplate = (id: string) => setDoseTemplates(prev => prev.filter(t => t.id !== id));
+
+    const addQuickDose = (dose: QuickDose) => setQuickDoses(prev => [...prev, dose]);
+    const deleteQuickDose = (id: string) => setQuickDoses(prev => prev.filter(d => d.id !== id));
 
     const sanitizeImportedEvents = (raw: any): DoseEvent[] => {
         if (!Array.isArray(raw)) throw new Error('Invalid format');
@@ -244,6 +260,7 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
         weight, setWeight,
         labResults, setLabResults,
         doseTemplates, setDoseTemplates,
+        quickDoses, setQuickDoses,
         simulation,
         currentTime,
         calibrationFn,
@@ -254,6 +271,7 @@ export const useAppData = (showDialog: (type: 'alert' | 'confirm', message: stri
         addEvent, updateEvent, deleteEvent, clearAllEvents,
         addLabResult, updateLabResult, deleteLabResult, clearLabResults,
         addTemplate, deleteTemplate,
+        addQuickDose, deleteQuickDose,
         processImportedData
     };
 };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -123,6 +123,11 @@ export const TRANSLATIONS_BASE = {
         "template.loaded": "模板已加载",
         "template.delete_confirm": "确定删除此模板吗？",
 
+        "quickdose.add": "保存当前剂量为快捷选项",
+        "quickdose.added": "快捷剂量已保存",
+        "quickdose.delete_confirm": "确定删除此快捷剂量吗？",
+        "quickdose.empty_input": "请先输入有效的剂量值",
+
         "dialog.confirm_title": "确认",
         "dialog.alert_title": "提示",
 
@@ -436,6 +441,11 @@ export const TRANSLATIONS_BASE = {
         "template.saved": "Template saved",
         "template.loaded": "Template loaded",
         "template.delete_confirm": "Delete this template?",
+
+        "quickdose.add": "Save current dose as quick option",
+        "quickdose.added": "Quick dose saved",
+        "quickdose.delete_confirm": "Delete this quick dose?",
+        "quickdose.empty_input": "Please enter a valid dose first",
 
         "dialog.confirm_title": "Confirm",
         "dialog.alert_title": "Alert",
@@ -815,6 +825,11 @@ export const TRANSLATIONS_BASE = {
         "template.loaded": "Шаблон загружен",
         "template.delete_confirm": "Удалить этот шаблон?",
 
+        "quickdose.add": "Сохранить текущую дозу как быструю",
+        "quickdose.added": "Быстрая доза сохранена",
+        "quickdose.delete_confirm": "Удалить эту быструю дозу?",
+        "quickdose.empty_input": "Сначала введите допустимую дозу",
+
         "dialog.confirm_title": "Подтверждение",
         "dialog.alert_title": "Внимание",
 
@@ -1073,6 +1088,11 @@ export const TRANSLATIONS = {
         "template.saved": "範本已儲存",
         "template.loaded": "範本已載入",
         "template.delete_confirm": "確定刪除此範本嗎？",
+
+        "quickdose.add": "儲存目前劑量為快捷選項",
+        "quickdose.added": "快捷劑量已儲存",
+        "quickdose.delete_confirm": "確定刪除此快捷劑量嗎？",
+        "quickdose.empty_input": "請先輸入有效的劑量值",
 
         "sl.instructions": "盡量避免吞嚥，在舌下含服直至達到目標時間。",
         "sl.tier.quick": "快速",
@@ -1386,6 +1406,11 @@ export const TRANSLATIONS = {
         "template.loaded": "範本已載入",
         "template.delete_confirm": "確定刪除呢個範本？",
 
+        "quickdose.add": "儲存依家劑量做快捷選項",
+        "quickdose.added": "快捷劑量已儲存",
+        "quickdose.delete_confirm": "確定刪除呢個快捷劑量？",
+        "quickdose.empty_input": "請先輸入有效嘅劑量值",
+
         "dialog.confirm_title": "確認",
         "dialog.alert_title": "提示",
 
@@ -1660,6 +1685,11 @@ export const TRANSLATIONS = {
         "template.saved": "Шаблон збережено",
         "template.loaded": "Шаблон завантажено",
         "template.delete_confirm": "Видалити цей шаблон?",
+
+        "quickdose.add": "Зберегти поточну дозу як швидку",
+        "quickdose.added": "Швидку дозу збережено",
+        "quickdose.delete_confirm": "Видалити цю швидку дозу?",
+        "quickdose.empty_input": "Спочатку введіть допустиму дозу",
 
         "dialog.confirm_title": "Підтвердження",
         "dialog.alert_title": "Увага",
@@ -1973,6 +2003,11 @@ export const TRANSLATIONS = {
         "template.saved": "テンプレートが保存されました",
         "template.loaded": "テンプレートが読み込まれました",
         "template.delete_confirm": "このテンプレートを削除しますか？",
+
+        "quickdose.add": "現在の用量をクイック選択肢として保存",
+        "quickdose.added": "クイック用量を保存しました",
+        "quickdose.delete_confirm": "このクイック用量を削除しますか？",
+        "quickdose.empty_input": "有効な用量を先に入力してください",
 
         "dialog.confirm_title": "確認",
         "dialog.alert_title": "お知らせ",
@@ -2298,6 +2333,11 @@ export const TRANSLATIONS = {
         "template.loaded": "템플릿을 불러왔습니다",
         "template.delete_confirm": "이 템플릿을 삭제하시겠습니까?",
 
+        "quickdose.add": "현재 용량을 빠른 선택으로 저장",
+        "quickdose.added": "빠른 용량이 저장되었습니다",
+        "quickdose.delete_confirm": "이 빠른 용량을 삭제하시겠습니까?",
+        "quickdose.empty_input": "먼저 유효한 용량을 입력하세요",
+
         "dialog.confirm_title": "확인",
         "dialog.alert_title": "알림",
 
@@ -2612,6 +2652,11 @@ export const TRANSLATIONS = {
         "template.loaded": "تم تحميل القالب",
         "template.delete_confirm": "حذف هذا القالب؟",
 
+        "quickdose.add": "حفظ الجرعة الحالية كخيار سريع",
+        "quickdose.added": "تم حفظ الجرعة السريعة",
+        "quickdose.delete_confirm": "حذف هذه الجرعة السريعة؟",
+        "quickdose.empty_input": "يرجى إدخال جرعة صالحة أولاً",
+
         "dialog.confirm_title": "تأكيد",
         "dialog.alert_title": "تنبيه",
 
@@ -2925,6 +2970,11 @@ export const TRANSLATIONS = {
         "template.saved": "תבנית נשמרה",
         "template.loaded": "תבנית נטענה",
         "template.delete_confirm": "למחוק תבנית זו?",
+
+        "quickdose.add": "שמור מנה נוכחית כאפשרות מהירה",
+        "quickdose.added": "מנה מהירה נשמרה",
+        "quickdose.delete_confirm": "למחוק מנה מהירה זו?",
+        "quickdose.empty_input": "אנא הזן מנה תקינה תחילה",
 
         "dialog.confirm_title": "אישור",
         "dialog.alert_title": "התראה",

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -4,6 +4,7 @@ import { DoseEvent, Route, Ester, ExtraKey, getToE2Factor } from '../../logic';
 import { formatTime, getRouteIcon } from '../utils/helpers';
 import DoseForm from '../components/DoseForm';
 import { DoseTemplate } from '../components/DoseFormModal';
+import { QuickDose } from '../components/dose_form/QuickDoseButtons';
 
 interface HistoryProps {
     t: (key: string) => string;
@@ -14,6 +15,9 @@ interface HistoryProps {
     onDeleteEvent: (id: string) => void;
     onSaveTemplate: (t: DoseTemplate) => void;
     onDeleteTemplate: (id: string) => void;
+    quickDoses?: QuickDose[];
+    onAddQuickDose?: (dose: QuickDose) => void;
+    onDeleteQuickDose?: (id: string) => void;
     groupedEvents: Record<string, DoseEvent[]>;
     onEditEvent: (e: DoseEvent) => void;
 }
@@ -27,6 +31,9 @@ const History: React.FC<HistoryProps> = ({
     onDeleteEvent,
     onSaveTemplate,
     onDeleteTemplate,
+    quickDoses = [],
+    onAddQuickDose,
+    onDeleteQuickDose,
     groupedEvents,
     onEditEvent
 }) => {
@@ -73,6 +80,9 @@ const History: React.FC<HistoryProps> = ({
                         templates={doseTemplates}
                         onSaveTemplate={onSaveTemplate}
                         onDeleteTemplate={onDeleteTemplate}
+                        quickDoses={quickDoses}
+                        onAddQuickDose={onAddQuickDose}
+                        onDeleteQuickDose={onDeleteQuickDose}
                         isInline={true}
                     />
                 </div>


### PR DESCRIPTION
Description: Added a row of quick dose selection buttons below the input fields for all administration routes (Injection, Oral, Sublingual, Gel, Patch). Users can easily save their current input as a quick option or apply previously saved dosages via chips. The data is persisted locally via localStorage. Included i18n support for all 10 languages.