### PR TITLE
fix: resolve chart date range limitation and desktop date picker positioning issues

### DIFF
--- a/logic.ts
+++ b/logic.ts
@@ -495,7 +495,11 @@ export function runSimulation(events: DoseEvent[], bodyWeightKG: number): Simula
         .map(e => ({ model: new PrecomputedEventModel(e, sortedEvents), ester: e.ester }));
 
     const startTime = sortedEvents[0].timeH - 24;
-    const endTime = sortedEvents[sortedEvents.length - 1].timeH + (24 * 14);
+    const nowH = Date.now() / 3600000; // Current time in hours since epoch
+    const endTime = Math.max(
+        sortedEvents[sortedEvents.length - 1].timeH + (24 * 14),
+        nowH + 24
+    );
     const steps = 1000;
 
     // Different Vd for E2 and CPA

--- a/logic.ts
+++ b/logic.ts
@@ -495,7 +495,7 @@ export function runSimulation(events: DoseEvent[], bodyWeightKG: number): Simula
         .map(e => ({ model: new PrecomputedEventModel(e, sortedEvents), ester: e.ester }));
 
     const startTime = sortedEvents[0].timeH - 24;
-    const nowH = Date.now() / 3600000; // Current time in hours since epoch
+    const nowH = Date.now() / (1000 * 60 * 60);
     const endTime = Math.max(
         sortedEvents[sortedEvents.length - 1].timeH + (24 * 14),
         nowH + 24

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -48,11 +48,11 @@ const DateTimePicker: React.FC<DateTimePickerProps> = ({
                 }
                 const trigger = anchorRef.current?.previousElementSibling;
                 if (trigger) {
-                    const rect = trigger.getBoundingClientRect();
                     setPositionStyle({
-                        top: rect.bottom + 8,
-                        left: rect.left,
-                        width: 320,
+                        top: '50%',
+                        left: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        width: 360,
                     });
                 }
             };

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -46,15 +46,12 @@ const DateTimePicker: React.FC<DateTimePickerProps> = ({
                     setPositionStyle({});
                     return;
                 }
-                const trigger = anchorRef.current?.previousElementSibling;
-                if (trigger) {
-                    setPositionStyle({
-                        top: '50%',
-                        left: '50%',
-                        transform: 'translate(-50%, -50%)',
-                        width: 360,
-                    });
-                }
+                setPositionStyle({
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    width: 360,
+                });
             };
             updatePosition();
             window.addEventListener('resize', updatePosition);


### PR DESCRIPTION
## Related Issues

Fixes #33 
Fixes #34 

## Summary

This PR fixes two separate issues in a single changeset:

1. The concentration chart simulation range stops at **14 days after the last record**, which prevents the chart from reaching the current date when no recent records exist
2. On wide desktop layouts, the date picker popup is too small and appears left-shifted instead of being centered

These changes are independent, low-risk fixes, and are grouped into one PR for convenience.

---

## 1. Fix chart date range limitation

### Problem

In `logic.ts`, `runSimulation()` currently hardcodes `endTime` to **last event time + 14 days**:

```typescript
const endTime = sortedEvents[sortedEvents.length - 1].timeH + (24 * 14);
```

Because of this, if the user has not recorded a new dose for more than 14 days, the overview chart no longer extends to the current date, making it impossible to inspect the estimated concentration around the present time.

### Change

Update `endTime` to use the larger value of:

- `last event time + 14 days`
- `current time + 24 hours`

### Updated code

```typescript
const nowH = Date.now() / 3600000;
const endTime = Math.max(
    sortedEvents[sortedEvents.length - 1].timeH + (24 * 14),
    nowH + 24
);
```

### Result

- Behavior remains unchanged when records exist within the last 14 days
- The chart now continues to the current date when the latest record is older than 14 days
- Users can still inspect the estimated concentration near “now”

---

## 2. Fix desktop date picker positioning

### Problem

In `DateTimePicker.tsx`, the desktop popup positioning uses fixed anchor-based values:

```typescript
setPositionStyle({
    top: rect.bottom + 8,
    left: rect.left,
    width: 320,
});
```

On wide desktop layouts, especially with a sidebar, this causes the date picker to:

- look too narrow
- appear aligned to the left side of the input
- feel visually unbalanced instead of centered like a dialog

### Change

For desktop (`>= 768px`), switch to viewport-centered positioning and slightly increase the popup width:

```typescript
setPositionStyle({
    top: '50%',
    left: '50%',
    transform: 'translate(-50%, -50%)',
    width: 360,
});
```

### Result

- the desktop date picker now appears centered
- the popup feels more appropriate on wide screens
- layouts with sidebars no longer make it look left-shifted
- mobile bottom-sheet behavior remains unchanged

---

## Impact

### Chart range fix
- Only updates end-time calculation in `runSimulation()` inside `logic.ts`
- Does not change the simulation model itself
- Does not affect data parsing, rendering, or routing behavior

### Date picker fix
- Only updates desktop popup positioning in `src/components/DateTimePicker.tsx`
- Does not affect date/time selection logic
- Does not affect mobile behavior

---

## Validation

### Chart fix
1. Create a medication record older than 14 days
2. Open the overview page
3. Confirm the chart extends to the current date instead of stopping at `last record + 14 days`

### Date picker fix
1. Open the add-record form on a wide desktop screen
2. Click the date input
3. Confirm the date picker is centered and sized more appropriately
4. Verify on mobile that the existing bottom-sheet behavior is unchanged

---

## Screenshots

### Chart - before
<img width="600" alt="图片" src="https://github.com/user-attachments/assets/3c2e3919-8f76-40d7-a00e-fc205b04f1e9" />

### Chart - after
<img width="600"  alt="图片" src="https://github.com/user-attachments/assets/b1699abe-b73d-4282-997b-1889e5eb79a2" />

### Date picker - before
<img width="600"  alt="图片" src="https://github.com/user-attachments/assets/aca75052-2d74-4e00-8e54-d4cd96eb8b17" />

### Date picker - after
<img width="600"  alt="图片" src="https://github.com/user-attachments/assets/54884273-b63b-4a49-980a-a22f05a35a43" />

---

## Risk / Compatibility

This PR contains two localized fixes only:

- one adjustment to the simulation end-time calculation
- one desktop-only UI positioning update for the date picker

Neither change affects data structures, APIs, or core business logic, so the overall risk is low and compatibility is preserved.