### PR TITLE
Polish UI: modals, selects, dose form, chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,7 +305,7 @@ const AppContent = () => {
     // Ah I missed destructuring `navItems` in line 59. Let me fix the destructuring.
 
     return (
-        <div className="h-screen w-full bg-[var(--color-m3-surface)] dark:bg-[var(--color-m3-dark-surface)] flex flex-col md:flex-row font-sans text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] select-none overflow-hidden transition-colors duration-300">
+        <div className="h-[100dvh] w-full bg-[var(--color-m3-surface)] dark:bg-[var(--color-m3-dark-surface)] flex flex-col md:flex-row font-sans text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] select-none overflow-hidden transition-colors duration-300">
             <Sidebar
                 navItems={navItems}
                 currentView={currentView}

--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -6,6 +6,7 @@ interface Option {
     value: string;
     label: string;
     icon?: React.ReactNode;
+    description?: string;
 }
 
 interface CustomSelectProps {
@@ -129,11 +130,16 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ value, onChange, options, l
                         </>
                     ) : (
                         <>
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center gap-2 min-w-0 flex-1">
                                 {selectedOption?.icon && <div className="text-gray-500 dark:text-gray-400">{selectedOption.icon}</div>}
-                                <span className="font-medium text-gray-900 dark:text-gray-100 text-sm">{selectedOption?.label || value}</span>
+                                <span className="font-medium text-gray-900 dark:text-gray-100 text-sm truncate">{selectedOption?.label || value}</span>
                             </div>
-                            <ChevronDown size={16} className={`text-gray-400 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
+                            <div className="flex items-center gap-1.5 shrink-0">
+                                {selectedOption?.description && (
+                                    <span className="text-xs text-gray-500 dark:text-gray-400">{selectedOption.description}</span>
+                                )}
+                                <ChevronDown size={16} className={`text-gray-400 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
+                            </div>
                         </>
                     )}
                 </button>
@@ -142,7 +148,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ value, onChange, options, l
                     <div
                         ref={dropdownRef}
                         style={positionStyle}
-                        className="fixed z-[999] bg-white dark:bg-neutral-900 border x border-gray-200 dark:border-neutral-800 border-t-0 rounded-b-md shadow-sm overflow-y-auto animate-in fade-in duration-100 py-1"
+                        className="fixed z-[999] bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 border-t-0 rounded-b-md shadow-sm overflow-y-auto animate-in fade-in duration-100 py-1"
                     >
                         {options.map(opt => (
                             <button
@@ -155,6 +161,11 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ value, onChange, options, l
                             >
                                 {opt.icon && <div className={`${opt.value === value ? 'text-inherit' : 'text-gray-400 dark:text-gray-500'}`}>{opt.icon}</div>}
                                 <span className="flex-1 text-sm">{opt.label}</span>
+                                {opt.description && (
+                                    <span className={`text-xs ${opt.value === value ? 'text-teal-600 dark:text-teal-300' : 'text-gray-500 dark:text-gray-400'}`}>
+                                        {opt.description}
+                                    </span>
+                                )}
                                 {opt.value === value && (
                                     <Check size={16} className="text-teal-600 dark:text-teal-400" strokeWidth={2.5} />
                                 )}

--- a/src/components/DisclaimerModal.tsx
+++ b/src/components/DisclaimerModal.tsx
@@ -11,18 +11,16 @@ const DisclaimerModal = ({ isOpen, onClose }: { isOpen: boolean, onClose: () => 
     if (!isOpen) return null;
 
     return (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[60] animate-in fade-in duration-200 p-6">
-            <div className="bg-[var(--color-m3-surface-container-high)] dark:bg-[var(--color-m3-dark-surface-container-high)] rounded-[var(--radius-xl)] shadow-[var(--shadow-m3-3)] w-full max-w-sm p-6 animate-m3-decelerate transition-colors duration-300">
+        <div className="fixed inset-0 bg-black/40 flex items-end md:items-center justify-center z-[60] p-0 md:p-4">
+            <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-t-2xl md:rounded-xl shadow-lg w-full max-w-sm p-5 max-h-[88vh] overflow-y-auto safe-area-pb">
                 <div className="flex flex-col items-center mb-4">
-                    <div className="w-10 h-10 rounded-[var(--radius-full)] bg-amber-50 dark:bg-amber-900/20 flex items-center justify-center mb-2 transition-colors">
-                        <AlertTriangle className="text-amber-500" size={20} />
-                    </div>
-                    <h3 className="font-display text-base font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] text-center transition-colors">{t('disclaimer.title')}</h3>
+                    <AlertTriangle className="text-amber-500 mb-2" size={20} />
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 text-center">{t('disclaimer.title')}</h3>
                 </div>
 
-                <div className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] space-y-2 mb-5 leading-relaxed transition-colors">
+                <div className="text-sm text-gray-600 dark:text-gray-300 space-y-2 mb-5 leading-relaxed">
                     <p>{t('disclaimer.text.intro')}</p>
-                    <ul className="list-disc pl-5 space-y-2 marker:text-[var(--color-m3-outline-variant)] dark:marker:text-[var(--color-m3-dark-outline-variant)]">
+                    <ul className="list-disc pl-5 space-y-2 marker:text-gray-400 dark:marker:text-gray-500">
                         <li>{t('disclaimer.text.point1')}</li>
                         <li>{t('disclaimer.text.point2')}</li>
                         <li>{t('disclaimer.text.point3')}</li>
@@ -31,7 +29,7 @@ const DisclaimerModal = ({ isOpen, onClose }: { isOpen: boolean, onClose: () => 
 
                 <button
                     onClick={onClose}
-                    className="w-full py-2.5 text-sm bg-[var(--color-m3-primary)] dark:bg-teal-600 text-[var(--color-m3-on-primary)] font-bold rounded-[var(--radius-full)] transition shadow-[var(--shadow-m3-1)]"
+                    className="w-full py-2.5 text-sm font-medium bg-teal-600 hover:bg-teal-700 text-white rounded-md"
                 >
                     {t('btn.ok')}
                 </button>

--- a/src/components/DoseForm.tsx
+++ b/src/components/DoseForm.tsx
@@ -40,11 +40,11 @@ const DOSE_GUIDE_CONFIG: Partial<Record<Route, DoseGuideConfig>> = {
 };
 
 const LEVEL_BADGE_STYLES: Record<DoseLevelKey, string> = {
-    low: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
-    medium: 'bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-200',
-    high: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
-    very_high: 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-200',
-    above: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200'
+    low: 'text-emerald-700 dark:text-emerald-300',
+    medium: 'text-sky-700 dark:text-sky-300',
+    high: 'text-amber-700 dark:text-amber-300',
+    very_high: 'text-rose-700 dark:text-rose-300',
+    above: 'text-red-700 dark:text-red-300'
 };
 
 const LEVEL_CONTAINER_STYLES: Record<DoseLevelKey | 'neutral', string> = {
@@ -496,21 +496,86 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
     const customTheta = thetaFromHold(customHoldValue);
     const guideUnitLabel = doseGuide?.config ? t(`dose.guide.unit.${doseGuide.config.unitKey}`) : "";
     const guideRangeText = doseGuide?.config
-        ? [
-            `${t('dose.guide.level.low')} ≤ ${formatGuideNumber(doseGuide.config.thresholds[0])} ${guideUnitLabel}`,
-            `${t('dose.guide.level.medium')} ≤ ${formatGuideNumber(doseGuide.config.thresholds[1])} ${guideUnitLabel}`,
-            `${t('dose.guide.level.high')} ≤ ${formatGuideNumber(doseGuide.config.thresholds[2])} ${guideUnitLabel}`,
-            `${t('dose.guide.level.very_high')} ≤ ${formatGuideNumber(doseGuide.config.thresholds[3])} ${guideUnitLabel}`,
-        ].join(' · ')
+        ? `${doseGuide.config.thresholds.map((threshold) => `≤ ${formatGuideNumber(threshold)}`).join(' · ')} ${guideUnitLabel}`
         : "";
-    const guideContainerClass = doseGuide
-        ? (
-            doseGuide.level
-                ? LEVEL_CONTAINER_STYLES[doseGuide.level]
-                : (doseGuide.showRateHint ? LEVEL_CONTAINER_STYLES.high : LEVEL_CONTAINER_STYLES.neutral)
-        )
-        : LEVEL_CONTAINER_STYLES.neutral;
     const guideBadgeClass = doseGuide?.level ? LEVEL_BADGE_STYLES[doseGuide.level] : "";
+    const confirmAndOpenExternal = (url: string) => {
+        const host = (() => {
+            try {
+                return new URL(url).hostname.replace(/^www\./, '');
+            } catch {
+                return url;
+            }
+        })();
+        const confirmText = t('drawer.model_confirm').replace('mahiro.uk', host);
+        showDialog('confirm', confirmText, () => {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        });
+    };
+    const renderLoadTemplateControl = () => {
+        if (eventToEdit) return null;
+
+        return (
+            <div className="relative">
+                <button
+                    onClick={() => {
+                        if (templates.length === 0) return;
+                        setShowTemplateMenu(!showTemplateMenu);
+                    }}
+                    disabled={templates.length === 0}
+                    className={`px-2.5 py-1.5 text-xs font-medium bg-white dark:bg-neutral-900 border rounded-md transition-colors flex items-center justify-center gap-1.5 ${
+                        templates.length === 0
+                            ? 'text-gray-400 dark:text-gray-500 border-gray-200 dark:border-neutral-700 cursor-not-allowed opacity-70'
+                            : 'text-gray-700 dark:text-gray-200 border-gray-200 dark:border-neutral-700 hover:border-teal-400'
+                    }`}
+                    title={t('template.load_title')}
+                >
+                    <Bookmark size={14} className={templates.length === 0 ? 'text-gray-400 dark:text-gray-500' : 'text-teal-600 dark:text-teal-400'} />
+                    <span>{t('template.load_title')}</span>
+                </button>
+                {showTemplateMenu && templates.length > 0 && (
+                    <div className="absolute right-0 top-full mt-2 bg-white dark:bg-neutral-900 rounded shadow-lg border border-gray-200 dark:border-neutral-800 w-64 max-h-64 overflow-y-auto z-50">
+                        <div className="p-2">
+                            {templates.map((template: DoseTemplate) => (
+                                <div key={template.id} className="group flex items-center justify-between p-2 hover:bg-gray-50 dark:hover:bg-neutral-800 rounded-md transition-colors">
+                                    <button
+                                        onClick={() => { handleLoadTemplate(template); setShowTemplateMenu(false); }}
+                                        className="flex-1 text-left"
+                                    >
+                                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{template.name}</div>
+                                        <div className="text-xs text-gray-500 mt-0.5">
+                                            {t(`route.${template.route}`)} · {template.doseMG.toFixed(2)} mg
+                                        </div>
+                                    </button>
+                                    {templateToDelete === template.id ? (
+                                        <div className="flex items-center space-x-1 pl-2" onClick={(e) => e.stopPropagation()}>
+                                            <button onClick={() => { setTemplateToDelete(null); setShowTemplateMenu(false); onDeleteTemplate(template.id); }} className="p-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 rounded" title={t('btn.confirm')}>
+                                                <Check size={14} />
+                                            </button>
+                                            <button onClick={() => setTemplateToDelete(null)} className="p-1 text-gray-500 hover:bg-gray-200 dark:hover:bg-neutral-700 rounded" title={t('btn.cancel')}>
+                                                <X size={14} />
+                                            </button>
+                                        </div>
+                                    ) : (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setTemplateToDelete(template.id);
+                                            }}
+                                            className="opacity-0 group-hover:opacity-100 p-1.5 text-gray-400 hover:text-red-500 rounded transition"
+                                            title={t('btn.delete')}
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </div>
+        );
+    };
 
     return (
         <div className={`flex flex-col h-full bg-white dark:bg-neutral-900 transition-colors duration-300 ${isInline && !hideHeader ? 'border flex-1 border-gray-200 dark:border-neutral-800' : ''}`}>
@@ -525,6 +590,7 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                         {eventToEdit ? t('modal.dose.edit_title') : t('modal.dose.add_title')}
                     </h3>
                     <div className="flex gap-2">
+                        {renderLoadTemplateControl()}
                         <button onClick={onCancel} className="p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded transition">
                             <X size={20} />
                         </button>
@@ -538,6 +604,7 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                     <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 px-2">
                         {t('timeline.add_title')}
                     </h3>
+                    {renderLoadTemplateControl()}
                 </div>
             )}
 
@@ -663,23 +730,23 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                         {route === Route.injection && (
                             <div className="mt-3 space-y-3">
                                 {/* Safety Warning */}
-                                <div className="p-3 rounded-[var(--radius-lg)] border border-amber-200 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-900/15 flex gap-3">
-                                    <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+                                <div className="p-3 rounded-xl border border-gray-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800/60 flex gap-3">
+                                    <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
                                     <div>
-                                        <span className="text-sm font-bold text-amber-800 dark:text-amber-300">{t('inj.guide.title')}</span>
-                                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1 font-semibold">{t('inj.guide.safety')}</p>
+                                        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{t('inj.guide.title')}</span>
+                                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">{t('inj.guide.safety')}</p>
                                     </div>
                                 </div>
 
                                 {/* Usage & Dosage */}
-                                <div className="p-3 rounded-[var(--radius-lg)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)] space-y-2">
-                                    <div className="flex items-center gap-1.5">
-                                        <span className="text-xs text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">{t('inj.guide.route_methods')}</span>
-                                        <span className="text-[10px] font-bold text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-1.5 py-0.5 rounded-[var(--radius-full)]">{t('inj.guide.route_warn')}</span>
+                                <div className="p-3 rounded-xl border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 space-y-2">
+                                    <div className="space-y-0.5">
+                                        <p className="text-xs text-gray-800 dark:text-gray-200">{t('inj.guide.route_methods')}</p>
+                                        <p className="text-[11px] font-medium text-red-600 dark:text-red-400">{t('inj.guide.route_warn')}</p>
                                     </div>
                                     <div>
-                                        <p className="text-xs font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">{t('inj.guide.dosage_title')}</p>
-                                        <ul className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] mt-1 space-y-0.5 list-disc list-inside">
+                                        <p className="text-xs font-semibold text-gray-800 dark:text-gray-200">{t('inj.guide.dosage_title')}</p>
+                                        <ul className="text-xs text-gray-600 dark:text-gray-300 mt-1 space-y-0.5 list-disc list-inside">
                                             <li>{t('inj.guide.dosage_ev')}</li>
                                             <li>{t('inj.guide.dosage_ec')}</li>
                                         </ul>
@@ -687,7 +754,11 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                             href="https://transfemscience.org/misc/injectable-e2-simulator/"
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            className="inline-flex items-center gap-1 text-xs text-[var(--color-m3-primary)] dark:text-teal-400 hover:underline mt-1"
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                confirmAndOpenExternal('https://transfemscience.org/misc/injectable-e2-simulator/');
+                                            }}
+                                            className="inline-flex items-center gap-1 text-xs text-teal-600 dark:text-teal-400 hover:underline mt-1"
                                         >
                                             {t('inj.guide.sim_link')}
                                             <ExternalLink size={12} />
@@ -696,9 +767,9 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                 </div>
 
                                 {/* Precautions */}
-                                <div className="p-3 rounded-[var(--radius-lg)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)] space-y-2">
-                                    <p className="text-xs font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">{t('inj.guide.notes_title')}</p>
-                                    <ul className="text-[11px] text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] space-y-1 list-disc list-inside leading-relaxed">
+                                <div className="p-3 rounded-xl border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 space-y-2">
+                                    <p className="text-xs font-semibold text-gray-800 dark:text-gray-200">{t('inj.guide.notes_title')}</p>
+                                    <ul className="text-[11px] text-gray-600 dark:text-gray-300 space-y-1 list-disc list-inside leading-relaxed">
                                         <li>{t('inj.guide.note_1')}</li>
                                         <li>{t('inj.guide.note_2')}</li>
                                         <li className="font-semibold text-red-600 dark:text-red-400">{t('inj.guide.note_3')}</li>
@@ -716,7 +787,11 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                                     href="https://mtf.wiki/zh-cn/docs/medicine/estrogen/injection"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1 text-[11px] text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] hover:text-[var(--color-m3-primary)] dark:hover:text-teal-400 transition-colors"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        confirmAndOpenExternal('https://mtf.wiki/zh-cn/docs/medicine/estrogen/injection');
+                                    }}
+                                    className="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
                                 >
                                     {t('inj.guide.source')}
                                     <ExternalLink size={11} />
@@ -744,27 +819,27 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
 
                         {/* Dose guide for non-injection routes */}
                         {doseGuide && (
-                            <div className={`mt-3 p-3 rounded-[var(--radius-lg)] border ${guideContainerClass} flex gap-3 transition-colors duration-300`}>
-                                <Info className="w-5 h-5 text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] shrink-0 mt-0.5" />
-                                <div className="space-y-1">
+                            <div className="mt-3 p-2.5 rounded-lg border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 flex gap-2 transition-colors duration-300">
+                                <Info className="w-4 h-4 text-gray-400 dark:text-gray-500 shrink-0 mt-0.5" />
+                                <div className="space-y-0.5 min-w-0">
                                     <div className="flex items-center gap-2">
-                                        <span className="text-sm font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">{t('dose.guide.title')}</span>
+                                        <span className="text-xs font-semibold text-gray-800 dark:text-gray-200">{t('dose.guide.title')}</span>
                                         {doseGuide.level && (
-                                            <span className={`text-xs font-semibold px-2 py-0.5 rounded-[var(--radius-full)] ${guideBadgeClass}`}>
+                                            <span className={`text-xs font-medium ${guideBadgeClass}`}>
                                                 {t(`dose.guide.level.${doseGuide.level}`)}
                                             </span>
                                         )}
                                     </div>
-                                    <p className="text-xs text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">
+                                    <p className="text-xs text-gray-700 dark:text-gray-300">
                                         {t('dose.guide.current')}: {doseGuide.value !== null ? `${formatGuideNumber(doseGuide.value)} ${guideUnitLabel}` : t('dose.guide.current_blank')}
                                     </p>
                                     {guideRangeText && (
-                                        <p className="text-[11px] text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] leading-relaxed">
+                                        <p className="text-[10px] text-gray-500 dark:text-gray-400 leading-snug">
                                             {t('dose.guide.reference')}: {guideRangeText}
                                         </p>
                                     )}
                                     {doseGuide.showRateHint && (
-                                        <p className="text-xs text-amber-700 dark:text-amber-500 leading-relaxed">
+                                        <p className="text-[11px] text-amber-700 dark:text-amber-500 leading-snug">
                                             {t('dose.guide.patch_rate_hint')}
                                         </p>
                                     )}
@@ -776,73 +851,20 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
             </div>
 
             {/* Footer Buttons */}
-            <div className={`px-4 py-3 border-t border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 flex justify-between items-center shrink-0 transition-colors duration-300 ${hideHeader ? '!p-2 !border-t-0 !bg-transparent' : ''}`}>
-                <div className="flex gap-2 items-center flex-wrap min-h-10">
-                    
-                    {/* Load Template Section */}
-                    {templates.length > 0 && (
-                        <div className="relative">
-                            <button
-                                onClick={() => setShowTemplateMenu(!showTemplateMenu)}
-                                className="p-2 text-amber-600 dark:text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20 border border-transparent rounded transition-colors flex items-center justify-center"
-                                title={t('template.load_title')}
-                            >
-                                <Bookmark size={18} />
-                            </button>
-                            {showTemplateMenu && (
-                                <div className="absolute left-0 bottom-full mb-2 bg-white dark:bg-neutral-900 rounded shadow-lg border border-gray-200 dark:border-neutral-800 w-64 max-h-64 overflow-y-auto z-50">
-                                    <div className="p-2">
-                                        {templates.map((template: DoseTemplate) => (
-                                            <div key={template.id} className="group flex items-center justify-between p-2 hover:bg-gray-50 dark:hover:bg-neutral-800 rounded-md transition-colors">
-                                                <button
-                                                    onClick={() => { handleLoadTemplate(template); setShowTemplateMenu(false); }}
-                                                    className="flex-1 text-left"
-                                                >
-                                                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{template.name}</div>
-                                                    <div className="text-xs text-gray-500 mt-0.5">
-                                                        {t(`route.${template.route}`)} · {template.doseMG.toFixed(2)} mg
-                                                    </div>
-                                                </button>
-                                                {templateToDelete === template.id ? (
-                                                    <div className="flex items-center space-x-1 pl-2" onClick={(e) => e.stopPropagation()}>
-                                                        <button onClick={() => { setTemplateToDelete(null); setShowTemplateMenu(false); onDeleteTemplate(template.id); }} className="p-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30 rounded" title={t('btn.confirm')}>
-                                                            <Check size={14} />
-                                                        </button>
-                                                        <button onClick={() => setTemplateToDelete(null)} className="p-1 text-gray-500 hover:bg-gray-200 dark:hover:bg-neutral-700 rounded" title={t('btn.cancel')}>
-                                                            <X size={14} />
-                                                        </button>
-                                                    </div>
-                                                ) : (
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            setTemplateToDelete(template.id);
-                                                        }}
-                                                        className="opacity-0 group-hover:opacity-100 p-1.5 text-gray-400 hover:text-red-500 rounded transition"
-                                                        title={t('btn.delete')}
-                                                    >
-                                                        <Trash2 size={14} />
-                                                    </button>
-                                                )}
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    )}
+            <div className={`px-4 py-3 border-t border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 flex flex-wrap gap-y-2 justify-between items-center shrink-0 transition-colors duration-300 ${hideHeader ? '!p-2 !border-t-0 !bg-transparent' : ''}`}>
+                <div className="flex gap-2 items-center flex-wrap min-h-10 w-full sm:w-auto">
 
                     {/* Template Save Section */}
                     <div className="flex items-center">
                         <div className={`overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] flex items-center ${
-                            showSaveTemplateInput ? 'w-48 sm:w-[13.5rem] opacity-100' : 'w-0 opacity-0'
+                            showSaveTemplateInput ? 'w-40 sm:w-[13.5rem] opacity-100' : 'w-0 opacity-0'
                         }`}>
                             <input
                                 type="text"
                                 value={templateName}
                                 onChange={(e) => setTemplateName(e.target.value)}
                                 placeholder={t('template.name_placeholder')}
-                                className="w-32 sm:w-36 px-2.5 py-1.5 text-sm bg-white dark:bg-neutral-900 border border-gray-300 dark:border-neutral-700 rounded focus:ring-1 focus:ring-teal-500 focus:border-teal-500 outline-none text-gray-900 dark:text-gray-100"
+                                className="w-24 sm:w-36 px-2.5 py-1.5 text-sm bg-white dark:bg-neutral-900 border border-gray-300 dark:border-neutral-700 rounded focus:ring-1 focus:ring-teal-500 focus:border-teal-500 outline-none text-gray-900 dark:text-gray-100"
                             />
                             <button
                                 onClick={handleSaveAsTemplate}
@@ -879,7 +901,7 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                     {eventToEdit && (
                         <div className="flex items-center">
                             <div className={`overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] flex items-center ${
-                                showDeleteConfirm ? 'w-36 sm:w-40 bg-red-50 dark:bg-red-900/10 border border-red-100 dark:border-red-900/30 rounded opacity-100 pl-3 pr-1 py-1' : 'w-0 opacity-0 border border-transparent'
+                                showDeleteConfirm ? 'w-[8.75rem] sm:w-40 bg-red-50 dark:bg-red-900/10 border border-red-100 dark:border-red-900/30 rounded opacity-100 pl-3 pr-1 py-1' : 'w-0 opacity-0 border border-transparent'
                             }`}>
                                 <span className="text-xs text-red-600 dark:text-red-400 font-medium whitespace-nowrap grow">{t('dialog.confirm_title')}?</span>
                                 <div className="flex items-center shrink-0 ml-2">
@@ -921,7 +943,7 @@ const DoseForm: React.FC<DoseFormProps> = ({ eventToEdit, onSave, onCancel, onDe
                     )}
                 </div>
 
-                <div className="flex gap-2 ml-auto shrink-0">
+                <div className="flex gap-2 ml-auto shrink-0 w-full sm:w-auto justify-end">
                     {hideHeader && (
                         <button
                             onClick={onCancel}

--- a/src/components/EstimateInfoModal.tsx
+++ b/src/components/EstimateInfoModal.tsx
@@ -12,18 +12,16 @@ const EstimateInfoModal = ({ isOpen, onClose }: { isOpen: boolean, onClose: () =
     if (!isOpen) return null;
 
     return createPortal(
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[60] animate-in fade-in duration-200 p-6">
-            <div className="bg-[var(--color-m3-surface-container-high)] dark:bg-[var(--color-m3-dark-surface-container-high)] rounded-[var(--radius-xl)] shadow-[var(--shadow-m3-3)] w-full max-w-sm p-6 animate-m3-decelerate transition-colors duration-300">
+        <div className="fixed inset-0 bg-black/40 flex items-end md:items-center justify-center z-[60] p-0 md:p-4">
+            <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-t-2xl md:rounded-xl shadow-lg w-full max-w-sm p-5 max-h-[88vh] overflow-y-auto safe-area-pb">
                 <div className="flex flex-col items-center mb-4">
-                    <div className="w-10 h-10 rounded-[var(--radius-full)] bg-[var(--color-m3-accent-container)] dark:bg-rose-900/20 flex items-center justify-center mb-2 transition-colors">
-                        <AlertTriangle className="text-[var(--color-m3-accent)]" size={20} />
-                    </div>
-                    <h3 className="font-display text-base font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] text-center transition-colors">{t('modal.estimate.title')}</h3>
+                    <AlertTriangle className="text-amber-500 mb-2" size={20} />
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 text-center">{t('modal.estimate.title')}</h3>
                 </div>
 
-                <div className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] space-y-3 mb-5 leading-relaxed transition-colors">
+                <div className="text-sm text-gray-600 dark:text-gray-300 space-y-3 mb-5 leading-relaxed">
                     <p>{t('modal.estimate.p1')}</p>
-                    <p className="font-medium text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] bg-[var(--color-m3-accent-container)] dark:bg-rose-900/10 p-2.5 rounded-[var(--radius-sm)] border border-[var(--color-m3-outline-variant)] dark:border-rose-900/20">
+                    <p className="font-medium text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-neutral-800 p-2.5 rounded-md border border-gray-200 dark:border-neutral-700">
                         {t('modal.estimate.p2')}
                     </p>
                     <p>{t('modal.estimate.p3')}</p>
@@ -31,7 +29,7 @@ const EstimateInfoModal = ({ isOpen, onClose }: { isOpen: boolean, onClose: () =
 
                 <button
                     onClick={onClose}
-                    className="w-full py-2.5 text-sm bg-[var(--color-m3-primary)] dark:bg-teal-600 text-[var(--color-m3-on-primary)] font-bold rounded-[var(--radius-full)] transition shadow-[var(--shadow-m3-1)]"
+                    className="w-full py-2.5 text-sm font-medium bg-teal-600 hover:bg-teal-700 text-white rounded-md"
                 >
                     {t('btn.ok')}
                 </button>

--- a/src/components/ExportSection.tsx
+++ b/src/components/ExportSection.tsx
@@ -67,10 +67,15 @@ const ExportSection: React.FC<ExportSectionProps> = ({ events, labResults, weigh
                                 <div className="relative">
                                     <input
                                         type="password"
+                                        name="export-encryption-password"
                                         value={password}
                                         onChange={(e) => setPassword(e.target.value)}
                                         placeholder={t('export.password_placeholder')}
                                         className="w-full py-2.5 px-3 pl-10 text-sm bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-lg outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
+                                        autoComplete="new-password"
+                                        autoCorrect="off"
+                                        autoCapitalize="off"
+                                        spellCheck={false}
                                     />
                                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
                                 </div>

--- a/src/components/ImportSection.tsx
+++ b/src/components/ImportSection.tsx
@@ -40,6 +40,10 @@ const ImportSection: React.FC<ImportSectionProps> = ({ onImportJson }) => {
                         placeholder={t('import.paste_hint')}
                         value={text}
                         onChange={e => setText(e.target.value)}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
                     />
                     <button
                         onClick={handleTextImport}

--- a/src/components/ResultChart.tsx
+++ b/src/components/ResultChart.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from '../contexts/LanguageContext';
 import { formatDate, formatTime } from '../utils/helpers';
 import { SimulationResult, DoseEvent, interpolateConcentration, interpolateConcentration_E2, interpolateConcentration_CPA, LabResult, convertToPgMl } from '../../logic';
-import { Activity, RotateCcw, Info, FlaskConical } from 'lucide-react';
+import { Activity, RotateCcw, Info, FlaskConical, Maximize2, Minimize2 } from 'lucide-react';
 import {
     XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, Area, AreaChart, ComposedChart, Scatter, Brush, Line
 } from 'recharts';
@@ -68,9 +69,14 @@ const CustomTooltip = ({ active, payload, label, t, lang, isDarkMode }: any) => 
 
 const ResultChart = ({ sim, events, labResults = [], calibrationFn = (_t: number) => 1, onPointClick, isDarkMode = false }: { sim: SimulationResult | null, events: DoseEvent[], labResults?: LabResult[], calibrationFn?: (timeH: number) => number, onPointClick: (e: DoseEvent) => void, isDarkMode?: boolean }) => {
     const { t, lang } = useTranslation();
-    const containerRef = useRef<HTMLDivElement>(null);
     const [xDomain, setXDomain] = useState<[number, number] | null>(null);
     const initializedRef = useRef(false);
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const getViewport = () => ({
+        width: typeof window !== 'undefined' ? window.innerWidth : 0,
+        height: typeof window !== 'undefined' ? window.innerHeight : 0,
+    });
+    const [viewport, setViewport] = useState(getViewport);
 
     // Auto-detect if we have E2 or CPA data
     const hasE2Data = useMemo(() => events.some(e => e.ester !== 'CPA'), [events]);
@@ -271,6 +277,344 @@ const ResultChart = ({ sim, events, labResults = [], calibrationFn = (_t: number
         setXDomain(clampDomain([start, end]));
     };
 
+    const lockLandscape = async () => {
+        try {
+            await (screen as any)?.orientation?.lock?.('landscape');
+        } catch {
+            // Ignore unsupported orientation lock on some browsers.
+        }
+    };
+
+    const unlockOrientation = () => {
+        try {
+            (screen as any)?.orientation?.unlock?.();
+        } catch {
+            // Ignore unsupported orientation unlock on some browsers.
+        }
+    };
+
+    const openFullscreenChart = async () => {
+        setIsFullscreen(true);
+        await lockLandscape();
+    };
+
+    const closeFullscreenChart = () => {
+        setIsFullscreen(false);
+        unlockOrientation();
+    };
+
+    useEffect(() => {
+        const handleResize = () => setViewport(getViewport());
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    useEffect(() => {
+        if (!isFullscreen) return;
+        const prevOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.body.style.overflow = prevOverflow;
+        };
+    }, [isFullscreen]);
+
+    useEffect(() => {
+        if (!isFullscreen) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') closeFullscreenChart();
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [isFullscreen]);
+
+    useEffect(() => {
+        return () => {
+            unlockOrientation();
+        };
+    }, []);
+
+    const isPortraitMobileFullscreen = isFullscreen && viewport.width < 768 && viewport.height > viewport.width;
+
+    const renderChartPanel = (fullscreen: boolean) => {
+        const chartHeightClass = fullscreen ? 'h-[58vh] md:h-[70vh] lg:h-[76vh]' : 'h-64 md:h-80 lg:h-96';
+        const miniMapGradientId = fullscreen ? 'overviewConcFullscreen' : 'overviewConc';
+
+        return (
+            <div className={`bg-white dark:bg-neutral-900 relative flex flex-col h-full uppercase tracking-wide ${fullscreen ? '' : 'border border-gray-200 dark:border-neutral-800 rounded-lg'}`}>
+                <div className={`flex justify-between items-center ${fullscreen ? 'px-4 md:px-6 py-3' : 'px-4 md:px-6 py-4'} border-b border-gray-100 dark:border-neutral-800`}>
+                    <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                        {t('chart.title')}
+                    </h2>
+
+                    <div className="flex items-center gap-2.5">
+                        <button
+                            onClick={fullscreen ? closeFullscreenChart : openFullscreenChart}
+                            className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                            title={fullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+                        >
+                            {fullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+                        </button>
+                        <button
+                            onClick={() => zoomToDuration(7)}
+                            className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                            title={t('chart.reset')}
+                        >
+                            <RotateCcw size={14} />
+                        </button>
+                    </div>
+                </div>
+
+                <div className={`${chartHeightClass} w-full touch-none relative select-none px-2 pb-2 mt-4`}>
+                    {(() => {
+                        const factorNow = calibrationFn(now / 3600000);
+                        return Math.abs(factorNow - 1) > 0.001 ? (
+                            <div className="absolute top-0 right-4 z-10 px-2 py-0.5 rounded border bg-white dark:bg-neutral-800 border-gray-200 dark:border-neutral-700 flex items-center gap-1 opacity-80 pointer-events-none">
+                                <FlaskConical size={10} className="text-gray-400 dark:text-gray-500" />
+                                <span className="text-[10px] text-gray-500 dark:text-gray-400">
+                                    ×{(factorNow ?? 1).toFixed(2)}
+                                </span>
+                            </div>
+                        ) : null;
+                    })()}
+                    <ResponsiveContainer width="100%" height="100%">
+
+                        <ComposedChart data={data} margin={{ top: 12, right: 10, bottom: 0, left: 10 }}>
+                            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={isDarkMode ? '#374151' : '#f2f4f7'} />
+                            <XAxis
+                                dataKey="time"
+                                type="number"
+                                domain={xDomain || ['auto', 'auto']}
+                                allowDataOverflow={true}
+                                tickFormatter={(ms) => formatDate(new Date(ms), lang)}
+                                tick={{ fontSize: 10, fill: isDarkMode ? '#9ca3af' : '#9aa3b1', fontWeight: 600 }}
+                                minTickGap={48}
+                                axisLine={false}
+                                tickLine={false}
+                                dy={10}
+                            />
+                            {hasE2Data && (
+                                <YAxis
+                                    yAxisId="left"
+                                    dataKey="concE2"
+                                    tick={{ fontSize: 10, fill: '#ec4899', fontWeight: 600 }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    width={50}
+                                    label={{ value: t('label.e2_unit'), angle: -90, position: 'left', offset: 0, style: { fontSize: 11, fill: '#ec4899', fontWeight: 700, textAnchor: 'middle' } }}
+                                />
+                            )}
+                            {hasCPAData && (
+                                <YAxis
+                                    yAxisId="right"
+                                    orientation="right"
+                                    dataKey="concCPA"
+                                    tick={{ fontSize: 10, fill: '#8b5cf6', fontWeight: 600 }}
+                                    axisLine={false}
+                                    tickLine={false}
+                                    width={50}
+                                    label={{ value: t('label.cpa_unit'), angle: 90, position: 'right', offset: 0, style: { fontSize: 11, fill: '#8b5cf6', fontWeight: 700, textAnchor: 'middle' } }}
+                                />
+                            )}
+                            <Tooltip
+                                content={<CustomTooltip t={t} lang={lang} isDarkMode={isDarkMode} />}
+                                cursor={{ stroke: isDarkMode ? '#f9a8d4' : '#f472b6', strokeWidth: 1, strokeDasharray: '4 4' }}
+                                trigger="hover"
+                            />
+                            {hasE2Data && (
+                                <ReferenceLine
+                                    x={now}
+                                    stroke="#f472b6"
+                                    strokeDasharray="3 3"
+                                    strokeWidth={1.2}
+                                    yAxisId="left"
+                                    ifOverflow="extendDomain"
+                                />
+                            )}
+                            {hasE2Data && (
+                                <Line
+                                    data={data}
+                                    type="linear"
+                                    dataKey="concE2"
+                                    yAxisId="left"
+                                    stroke="#f472b6"
+                                    strokeWidth={2}
+                                    dot={false}
+                                    isAnimationActive={false}
+                                    activeDot={{ r: 6, strokeWidth: 3, stroke: '#fff', fill: '#ec4899' }}
+                                />
+                            )}
+                            {hasCPAData && (
+                                <Line
+                                    data={data}
+                                    type="monotone"
+                                    dataKey="concCPA"
+                                    yAxisId="right"
+                                    stroke="#8b5cf6"
+                                    strokeWidth={2}
+                                    dot={false}
+                                    isAnimationActive={false}
+                                    activeDot={{ r: 6, strokeWidth: 3, stroke: '#fff', fill: '#7c3aed' }}
+                                />
+                            )}
+                            {eventPoints?.e2Points && eventPoints.e2Points.length > 0 && (
+                                <Scatter
+                                    data={eventPoints.e2Points}
+                                    yAxisId="left"
+                                    dataKey="concE2"
+                                    isAnimationActive={false}
+                                    onClick={(entry) => {
+                                        if (entry && entry.payload && entry.payload.event) {
+                                            onPointClick(entry.payload.event);
+                                        }
+                                    }}
+                                    shape={({ cx, cy }: any) => (
+                                        <g className="cursor-pointer">
+                                            <circle cx={cx} cy={cy} r={6} fill="#fff7ed" stroke="#fb923c" strokeWidth={1.6} />
+                                            <circle cx={cx} cy={cy} r={3} fill="#f97316" />
+                                        </g>
+                                    )}
+                                />
+                            )}
+                            {hasCPAData && cpaEventPoints.length > 0 && (
+                                <Scatter
+                                    data={cpaEventPoints}
+                                    yAxisId="right"
+                                    dataKey="concCPA"
+                                    isAnimationActive={false}
+                                    onClick={(entry) => {
+                                        if (entry && entry.payload && entry.payload.event) {
+                                            onPointClick(entry.payload.event);
+                                        }
+                                    }}
+                                    shape={({ cx, cy }: any) => (
+                                        <g className="cursor-pointer">
+                                            <circle cx={cx} cy={cy} r={6} fill="#faf5ff" stroke="#a855f7" strokeWidth={1.6} />
+                                            <circle cx={cx} cy={cy} r={3} fill="#8b5cf6" />
+                                        </g>
+                                    )}
+                                />
+                            )}
+                            {hasE2Data && (
+                                <Scatter
+                                    data={nowPoint ? [nowPoint] : []}
+                                    yAxisId="left"
+                                    isAnimationActive={false}
+                                    shape={({ cx, cy, payload }: any) => {
+                                        const conc = payload?.concE2 ?? 0;
+                                        const radius = Math.max(4, Math.min(7, 4 + conc / 80));
+                                        return (
+                                            <g className="group">
+                                                <circle cx={cx} cy={cy} r={1} fill="transparent" />
+                                                <circle
+                                                    cx={cx} cy={cy}
+                                                    r={radius}
+                                                    fill="#bfdbfe"
+                                                    stroke="white"
+                                                    strokeWidth={1.5}
+                                                />
+                                            </g>
+                                        );
+                                    }}
+                                />
+                            )}
+                            {hasCPAData && (
+                                <Scatter
+                                    data={nowPoint ? [nowPoint] : []}
+                                    yAxisId="right"
+                                    isAnimationActive={false}
+                                    shape={({ cx, cy, payload }: any) => {
+                                        const conc = payload?.concCPA ?? 0;
+                                        const radius = Math.max(4, Math.min(9, 4 + conc / 8));
+                                        return (
+                                            <g className="group">
+                                                <circle cx={cx} cy={cy} r={1} fill="transparent" />
+                                                <circle
+                                                    cx={cx} cy={cy}
+                                                    r={radius}
+                                                    fill="#c4b5fd"
+                                                    stroke="white"
+                                                    strokeWidth={1.5}
+                                                />
+                                            </g>
+                                        );
+                                    }}
+                                />
+                            )}
+                            {labPoints.length > 0 && (
+                                <Scatter
+                                    data={labPoints}
+                                    yAxisId="left"
+                                    dataKey="concE2"
+                                    isAnimationActive={false}
+                                    shape={({ cx, cy }: any) => (
+                                        <g>
+                                            <circle cx={cx} cy={cy} r={6} fill="#14b8a6" stroke="white" strokeWidth={2} />
+                                            <g transform={`translate(${(cx ?? 0) - 6}, ${(cy ?? 0) - 6})`}>
+                                                <FlaskConical size={12} color="white" />
+                                            </g>
+                                        </g>
+                                    )}
+                                />
+                            )}
+                        </ComposedChart>
+                    </ResponsiveContainer>
+                </div>
+
+                {data.length > 1 && (
+                    <div className={`${fullscreen ? 'px-4 md:px-6 pb-4 mt-1' : 'px-5 pb-5 mt-2'}`}>
+                        <div className="w-full h-12 bg-gray-50 dark:bg-neutral-800/50 border border-gray-200 dark:border-neutral-800 rounded overflow-hidden">
+                            <ResponsiveContainer width="100%" height="100%">
+                                <AreaChart data={data} margin={{ top: 4, right: 0, left: 0, bottom: 4 }}>
+                                    <defs>
+                                        <linearGradient id={miniMapGradientId} x1="0" y1="0" x2="0" y2="1">
+                                            <stop offset="5%" stopColor={isDarkMode ? '#525252' : '#e5e7eb'} stopOpacity={0.8} />
+                                            <stop offset="95%" stopColor={isDarkMode ? '#525252' : '#e5e7eb'} stopOpacity={0.1} />
+                                        </linearGradient>
+                                    </defs>
+                                    <XAxis
+                                        dataKey="time"
+                                        type="number"
+                                        hide
+                                        domain={[minTime, maxTime]}
+                                    />
+                                    <YAxis dataKey="conc" hide />
+                                    <Area
+                                        type="monotone"
+                                        dataKey="conc"
+                                        stroke={isDarkMode ? '#525252' : '#d1d5db'}
+                                        strokeWidth={1}
+                                        fill={`url(#${miniMapGradientId})`}
+                                        isAnimationActive={false}
+                                    />
+                                    <Brush
+                                        dataKey="time"
+                                        height={20}
+                                        stroke={isDarkMode ? '#737373' : '#9ca3af'}
+                                        fill={isDarkMode ? '#171717' : '#ffffff'}
+                                        startIndex={brushRange.startIndex}
+                                        endIndex={brushRange.endIndex}
+                                        travellerWidth={8}
+                                        tickFormatter={(ms) => formatDate(new Date(ms), lang)}
+                                        onChange={handleBrushChange}
+                                    >
+                                        <Area
+                                            type="monotone"
+                                            dataKey="conc"
+                                            stroke="none"
+                                            fill={isDarkMode ? '#404040' : '#d1d5db'}
+                                            fillOpacity={0.4}
+                                            isAnimationActive={false}
+                                        />
+                                    </Brush>
+                                </AreaChart>
+                            </ResponsiveContainer>
+                        </div>
+                    </div>
+                )}
+            </div>
+        );
+    };
+
     if (!sim || sim.timeH.length === 0) return (
         <div className="h-72 md:h-96 flex flex-col items-center justify-center text-gray-500 dark:text-gray-400 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg p-8">
             <Activity className="w-12 h-12 mb-4 text-gray-300 dark:text-gray-600" strokeWidth={1} />
@@ -279,275 +623,25 @@ const ResultChart = ({ sim, events, labResults = [], calibrationFn = (_t: number
     );
 
     return (
-        <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg relative flex flex-col h-full uppercase tracking-wide">
-            <div className="flex justify-between items-center px-4 md:px-6 py-4 border-b border-gray-100 dark:border-neutral-800">
-                <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
-                    {t('chart.title')}
-                </h2>
-
-                <div className="flex items-center gap-3">
-                    <button
-                        onClick={() => zoomToDuration(7)}
-                        className="p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
-                        title="Reset Zoom"
-                    >
-                        <RotateCcw size={14} />
-                    </button>
-                </div>
-            </div>
-
-            <div
-                ref={containerRef}
-                className="h-64 md:h-80 lg:h-96 w-full touch-none relative select-none px-2 pb-2 mt-4">
-                {(() => {
-                    const factorNow = calibrationFn(now / 3600000);
-                    return Math.abs(factorNow - 1) > 0.001 ? (
-                        <div className="absolute top-0 right-4 z-10 px-2 py-0.5 rounded border bg-white dark:bg-neutral-800 border-gray-200 dark:border-neutral-700 flex items-center gap-1 opacity-80 pointer-events-none">
-                            <FlaskConical size={10} className="text-gray-400 dark:text-gray-500" />
-                            <span className="text-[10px] text-gray-500 dark:text-gray-400">
-                                ×{(factorNow ?? 1).toFixed(2)}
-                            </span>
+        <>
+            {renderChartPanel(false)}
+            {isFullscreen && createPortal(
+                <div className="fixed inset-0 z-[120] bg-white dark:bg-neutral-900">
+                    {isPortraitMobileFullscreen ? (
+                        <div className="h-full w-full flex items-center justify-center overflow-hidden">
+                            <div className="origin-center rotate-90" style={{ width: viewport.height, height: viewport.width }}>
+                                {renderChartPanel(true)}
+                            </div>
                         </div>
-                    ) : null;
-                })()}
-                <ResponsiveContainer width="100%" height="100%">
-
-                    <ComposedChart data={data} margin={{ top: 12, right: 10, bottom: 0, left: 10 }}>
-                        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={isDarkMode ? '#374151' : '#f2f4f7'} />
-                        <XAxis
-                            dataKey="time"
-                            type="number"
-                            domain={xDomain || ['auto', 'auto']}
-                            allowDataOverflow={true}
-                            tickFormatter={(ms) => formatDate(new Date(ms), lang)}
-                            tick={{ fontSize: 10, fill: isDarkMode ? '#9ca3af' : '#9aa3b1', fontWeight: 600 }}
-                            minTickGap={48}
-                            axisLine={false}
-                            tickLine={false}
-                            dy={10}
-                        />
-                        {hasE2Data && (
-                            <YAxis
-                                yAxisId="left"
-                                dataKey="concE2"
-                                tick={{ fontSize: 10, fill: '#ec4899', fontWeight: 600 }}
-                                axisLine={false}
-                                tickLine={false}
-                                width={50}
-                                label={{ value: t('label.e2_unit'), angle: -90, position: 'left', offset: 0, style: { fontSize: 11, fill: '#ec4899', fontWeight: 700, textAnchor: 'middle' } }}
-                            />
-                        )}
-                        {hasCPAData && (
-                            <YAxis
-                                yAxisId="right"
-                                orientation="right"
-                                dataKey="concCPA"
-                                tick={{ fontSize: 10, fill: '#8b5cf6', fontWeight: 600 }}
-                                axisLine={false}
-                                tickLine={false}
-                                width={50}
-                                label={{ value: t('label.cpa_unit'), angle: 90, position: 'right', offset: 0, style: { fontSize: 11, fill: '#8b5cf6', fontWeight: 700, textAnchor: 'middle' } }}
-                            />
-                        )}
-                        <Tooltip
-                            content={<CustomTooltip t={t} lang={lang} isDarkMode={isDarkMode} />}
-                            cursor={{ stroke: isDarkMode ? '#f9a8d4' : '#f472b6', strokeWidth: 1, strokeDasharray: '4 4' }}
-                            trigger="hover"
-                        />
-                        {hasE2Data && (
-                            <ReferenceLine
-                                x={now}
-                                stroke="#f472b6"
-                                strokeDasharray="3 3"
-                                strokeWidth={1.2}
-                                yAxisId="left"
-                                ifOverflow="extendDomain"
-                            />
-                        )}
-                        {hasE2Data && (
-                            <Line
-                                data={data}
-                                type="linear"
-                                dataKey="concE2"
-                                yAxisId="left"
-                                stroke="#f472b6"
-                                strokeWidth={2}
-                                dot={false}
-                                isAnimationActive={false}
-                                activeDot={{ r: 6, strokeWidth: 3, stroke: '#fff', fill: '#ec4899' }}
-                            />
-                        )}
-                        {hasCPAData && (
-                            <Line
-                                data={data}
-                                type="monotone"
-                                dataKey="concCPA"
-                                yAxisId="right"
-                                stroke="#8b5cf6"
-                                strokeWidth={2}
-                                dot={false}
-                                isAnimationActive={false}
-                                activeDot={{ r: 6, strokeWidth: 3, stroke: '#fff', fill: '#7c3aed' }}
-                            />
-                        )}
-                        {/* E2 Event Points */}
-                        {eventPoints?.e2Points && eventPoints.e2Points.length > 0 && (
-                            <Scatter
-                                data={eventPoints.e2Points}
-                                yAxisId="left"
-                                dataKey="concE2"
-                                isAnimationActive={false}
-                                onClick={(entry) => {
-                                    if (entry && entry.payload && entry.payload.event) {
-                                        onPointClick(entry.payload.event);
-                                    }
-                                }}
-                                shape={({ cx, cy }: any) => (
-                                    <g className="cursor-pointer">
-                                        <circle cx={cx} cy={cy} r={6} fill="#fff7ed" stroke="#fb923c" strokeWidth={1.6} />
-                                        <circle cx={cx} cy={cy} r={3} fill="#f97316" />
-                                    </g>
-                                )}
-                            />
-                        )}
-                        {/* CPA Event Points */}
-                        {hasCPAData && cpaEventPoints.length > 0 && (
-                            <Scatter
-                                data={cpaEventPoints}
-                                yAxisId="right"
-                                dataKey="concCPA"
-                                isAnimationActive={false}
-                                onClick={(entry) => {
-                                    if (entry && entry.payload && entry.payload.event) {
-                                        onPointClick(entry.payload.event);
-                                    }
-                                }}
-                                shape={({ cx, cy }: any) => (
-                                    <g className="cursor-pointer">
-                                        <circle cx={cx} cy={cy} r={6} fill="#faf5ff" stroke="#a855f7" strokeWidth={1.6} />
-                                        <circle cx={cx} cy={cy} r={3} fill="#8b5cf6" />
-                                    </g>
-                                )}
-                            />
-                        )}
-                        {hasE2Data && (
-                            <Scatter
-                                data={nowPoint ? [nowPoint] : []}
-                                yAxisId="left"
-                                isAnimationActive={false}
-                                shape={({ cx, cy, payload }: any) => {
-                                    const conc = payload?.concE2 ?? 0;
-                                    const radius = Math.max(4, Math.min(7, 4 + conc / 80)); // Scale dot size with live E2 but cap size
-                                    return (
-                                        <g className="group">
-                                            <circle cx={cx} cy={cy} r={1} fill="transparent" />
-                                            <circle
-                                                cx={cx} cy={cy}
-                                                r={radius}
-                                                fill="#bfdbfe"
-                                                stroke="white"
-                                                strokeWidth={1.5}
-                                            />
-                                        </g>
-                                    );
-                                }}
-                            />
-                        )}
-                        {hasCPAData && (
-                            <Scatter
-                                data={nowPoint ? [nowPoint] : []}
-                                yAxisId="right"
-                                isAnimationActive={false}
-                                shape={({ cx, cy, payload }: any) => {
-                                    const conc = payload?.concCPA ?? 0;
-                                    const radius = Math.max(4, Math.min(9, 4 + conc / 8)); // Scale dot size with live CPA but cap size
-                                    return (
-                                        <g className="group">
-                                            <circle cx={cx} cy={cy} r={1} fill="transparent" />
-                                            <circle
-                                                cx={cx} cy={cy}
-                                                r={radius}
-                                                fill="#c4b5fd"
-                                                stroke="white"
-                                                strokeWidth={1.5}
-                                            />
-                                        </g>
-                                    );
-                                }}
-                            />
-                        )}
-                        {labPoints.length > 0 && (
-                            <Scatter
-                                data={labPoints}
-                                yAxisId="left"
-                                dataKey="concE2"
-                                isAnimationActive={false}
-                                shape={({ cx, cy }: any) => (
-                                    <g>
-                                        <circle cx={cx} cy={cy} r={6} fill="#14b8a6" stroke="white" strokeWidth={2} />
-                                        <g transform={`translate(${(cx ?? 0) - 6}, ${(cy ?? 0) - 6})`}>
-                                            <FlaskConical size={12} color="white" />
-                                        </g>
-                                    </g>
-                                )}
-                            />
-                        )}
-                    </ComposedChart>
-                </ResponsiveContainer>
-            </div>
-            {/* Overview mini-map with draggable handles */}
-            {data.length > 1 && (
-                <div className="px-5 pb-5 mt-2">
-                    <div className="w-full h-12 bg-gray-50 dark:bg-neutral-800/50 border border-gray-200 dark:border-neutral-800 rounded overflow-hidden">
-                        <ResponsiveContainer width="100%" height="100%">
-                            <AreaChart data={data} margin={{ top: 4, right: 0, left: 0, bottom: 4 }}>
-                                <defs>
-                                    <linearGradient id="overviewConc" x1="0" y1="0" x2="0" y2="1">
-                                        <stop offset="5%" stopColor={isDarkMode ? "#525252" : "#e5e7eb"} stopOpacity={0.8} />
-                                        <stop offset="95%" stopColor={isDarkMode ? "#525252" : "#e5e7eb"} stopOpacity={0.1} />
-                                    </linearGradient>
-                                </defs>
-                                <XAxis
-                                    dataKey="time"
-                                    type="number"
-                                    hide
-                                    domain={[minTime, maxTime]}
-                                />
-                                <YAxis dataKey="conc" hide />
-                                <Area
-                                    type="monotone"
-                                    dataKey="conc"
-                                    stroke={isDarkMode ? "#525252" : "#d1d5db"}
-                                    strokeWidth={1}
-                                    fill="url(#overviewConc)"
-                                    isAnimationActive={false}
-                                />
-                                <Brush
-                                    dataKey="time"
-                                    height={20}
-                                    stroke={isDarkMode ? "#737373" : "#9ca3af"}
-                                    fill={isDarkMode ? "#171717" : "#ffffff"}
-                                    startIndex={brushRange.startIndex}
-                                    endIndex={brushRange.endIndex}
-                                    travellerWidth={8}
-                                    tickFormatter={(ms) => formatDate(new Date(ms), lang)}
-                                    onChange={handleBrushChange}
-                                >
-                                    <Area
-                                        type="monotone"
-                                        dataKey="conc"
-                                        stroke="none"
-                                        fill={isDarkMode ? "#404040" : "#d1d5db"}
-                                        fillOpacity={0.4}
-                                        isAnimationActive={false}
-                                    />
-                                </Brush>
-                            </AreaChart>
-                        </ResponsiveContainer>
-                    </div>
-                </div>
+                    ) : (
+                        <div className="h-full w-full">
+                            {renderChartPanel(true)}
+                        </div>
+                    )}
+                </div>,
+                document.body
             )}
-        </div>
+        </>
     );
 };
 

--- a/src/components/dose_form/InjectionFields.tsx
+++ b/src/components/dose_form/InjectionFields.tsx
@@ -37,23 +37,23 @@ const InjectionFields: React.FC<InjectionFieldsProps> = ({
 
 
     return (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {(ester !== Ester.E2) && (
                 <div className={`space-y-2 ${(ester === Ester.EV && (route === Route.injection)) ? 'col-span-2' : ''}`}>
-                    <label className="block text-xs font-bold text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] uppercase tracking-wider">{t('field.dose_raw')}</label>
+                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 pl-1">{t('field.dose_raw')}</label>
                     <input
                         type="number" inputMode="decimal"
                         min="0"
                         step="0.001"
                         value={rawDose} onChange={e => onRawChange(e.target.value)}
-                        className="w-full p-4 bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] rounded-[var(--radius-lg)] focus:ring-2 focus:ring-[var(--color-m3-primary-container)] focus:border-[var(--color-m3-primary)] dark:focus:border-teal-400 outline-none font-mono text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] font-bold"
+                        className="w-full p-3 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-xl focus:ring-1 focus:ring-teal-500 focus:border-teal-500 outline-none text-gray-900 dark:text-gray-100 font-medium text-sm transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                         placeholder="0.0"
                     />
                 </div>
             )}
             {!(ester === Ester.EV && route === Route.injection) && ester !== Ester.CPA && (
                 <div className={`space-y-2 ${(ester === Ester.E2) ? "col-span-2" : ""}`}>
-                    <label className="block text-xs font-bold text-[var(--color-m3-accent)] uppercase tracking-wider">
+                    <label className="block text-xs font-semibold text-rose-500 dark:text-rose-400 pl-1">
                         {t('field.dose_e2')}
                     </label>
                     <input
@@ -61,7 +61,7 @@ const InjectionFields: React.FC<InjectionFieldsProps> = ({
                         min="0"
                         step="0.001"
                         value={e2Dose} onChange={e => onE2Change(e.target.value)}
-                        className="w-full p-4 bg-[var(--color-m3-accent-container)] dark:bg-rose-900/20 border border-[var(--color-m3-outline-variant)] dark:border-rose-900/30 rounded-[var(--radius-lg)] focus:ring-2 focus:ring-[var(--color-m3-accent)]/30 outline-none font-bold text-[var(--color-m3-accent)] dark:text-rose-400 font-mono"
+                        className="w-full p-3 bg-white dark:bg-neutral-900 border border-rose-200 dark:border-rose-900/50 rounded-xl focus:ring-1 focus:ring-rose-500 focus:border-rose-500 outline-none text-rose-600 dark:text-rose-400 font-medium text-sm transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                         placeholder="0.0"
                     />
                 </div>
@@ -69,7 +69,7 @@ const InjectionFields: React.FC<InjectionFieldsProps> = ({
 
             {(ester === Ester.EV && route === Route.injection) && (
                 <div className="col-span-2">
-                    <p className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] mt-1">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 pl-1">
                         {t('field.dose_e2')}: {e2Dose ? `${e2Dose} mg` : '--'}
                     </p>
                 </div>

--- a/src/components/dose_form/SublingualFields.tsx
+++ b/src/components/dose_form/SublingualFields.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from '../../contexts/LanguageContext';
 import { Route, Ester, SL_TIER_ORDER, SublingualTierParams, getToE2Factor } from '../../../logic';
-import { ChevronDown, Check, Info, Clock } from 'lucide-react';
 import CustomSelect from '../CustomSelect';
 
 interface SublingualFieldsProps {
@@ -59,92 +58,70 @@ const SublingualFields: React.FC<SublingualFieldsProps> = ({
         }
     };
 
+    const tierOptions = SL_TIER_ORDER.map((tierKey, index) => ({
+        value: String(index),
+        label: t(`sl.tier.${tierKey}`),
+        description: `${SublingualTierParams[tierKey].hold} min`
+    }));
+
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <div className="space-y-3">
                 <div className="flex justify-between items-center">
-                    <label className="block text-xs font-bold text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] uppercase tracking-wider">{t('field.sl_absorption')}</label>
+                    <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 pl-1">{t('field.sl_absorption')}</label>
                     <button
                         onClick={() => setUseCustomTheta(!useCustomTheta)}
-                        className="text-xs font-bold text-[var(--color-m3-primary)] dark:text-teal-400 transition"
+                        className="text-xs font-semibold text-teal-600 dark:text-teal-400"
                     >
                         {useCustomTheta ? t('sl.use_presets') : t('sl.use_custom')}
                     </button>
                 </div>
 
                 {!useCustomTheta ? (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        {SL_TIER_ORDER.map((tierKey, index) => {
-                            const tierParams = SublingualTierParams[tierKey];
-                            const active = slTier === index;
-                            return (
-                                <button
-                                    key={tierKey}
-                                    onClick={() => setSlTier(index)}
-                                    className={`relative p-3 rounded-[var(--radius-md)] border-2 text-start transition-all ${active
-                                        ? 'border-[var(--color-m3-primary)] bg-[var(--color-m3-primary-container)] dark:bg-teal-900/20 ring-2 ring-[var(--color-m3-primary-container)] dark:ring-teal-900/30'
-                                        : 'border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] hover:border-[var(--color-m3-primary)] dark:hover:border-teal-400 bg-[var(--color-m3-surface-container-lowest)] dark:bg-[var(--color-m3-dark-surface-container-high)]'
-                                        }`}
-                                >
-                                    <div className="flex items-center justify-between mb-1">
-                                        <div className={`font-bold ${active ? 'text-[var(--color-m3-primary)] dark:text-teal-400' : 'text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]'}`}>
-                                            {t(`sl.tier.${tierKey}`)}
-                                        </div>
-                                        {active && <Check size={16} className="text-[var(--color-m3-primary)] dark:text-teal-400" />}
-                                    </div>
-                                    <div className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)]">
-                                        {tierParams.hold} min hold
-                                    </div>
-                                </button>
-                            );
-                        })}
-                    </div>
+                    <CustomSelect
+                        value={String(slTier)}
+                        onChange={(val) => setSlTier(parseInt(val, 10))}
+                        options={tierOptions}
+                    />
                 ) : (
-                    <div className="bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)] p-4 rounded-[var(--radius-md)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)]">
-                        <div className="flex items-center gap-2 mb-2">
-                            <Clock size={16} className="text-[var(--color-m3-primary)] dark:text-teal-400" />
-                            <label className="text-sm font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]">{t('sl.hold_time_min')}</label>
-                        </div>
-                        <div className="flex gap-4 items-center">
+                    <div className="p-3 rounded-lg border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 space-y-2">
+                        <label className="text-xs font-medium text-gray-600 dark:text-gray-300 pl-0.5">{t('sl.hold_time_min')}</label>
+                        <div className="flex items-center gap-2">
                             <input
                                 type="number" inputMode="decimal"
                                 min="1" max="60"
                                 value={customHoldInput}
                                 onChange={e => handleCustomHoldChange(e.target.value)}
-                                className="w-24 p-3 bg-[var(--color-m3-surface-container-lowest)] dark:bg-[var(--color-m3-dark-surface-container-low)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] rounded-[var(--radius-md)] font-bold text-center focus:ring-2 focus:ring-[var(--color-m3-primary-container)] focus:border-[var(--color-m3-primary)] outline-none text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)]"
+                                className="w-16 h-9 px-2 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-md text-center text-sm font-medium focus:ring-1 focus:ring-teal-500 focus:border-teal-500 outline-none text-gray-900 dark:text-gray-100 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                             />
-                            <div className="flex-1">
-                                <input
-                                    type="range"
-                                    min="1" max="60"
-                                    value={customHoldValue}
-                                    onChange={e => {
-                                        const v = parseInt(e.target.value);
-                                        setCustomHoldValue(v);
-                                        setCustomHoldInput(v.toString());
-                                    }}
-                                    className="w-full accent-[var(--color-m3-primary)]"
-                                />
-                            </div>
+                            <span className="text-xs text-gray-500 dark:text-gray-400">min</span>
+                            <input
+                                type="range"
+                                min="1" max="60"
+                                value={customHoldValue}
+                                onChange={e => {
+                                    const v = parseInt(e.target.value);
+                                    setCustomHoldValue(v);
+                                    setCustomHoldInput(v.toString());
+                                }}
+                                className="flex-1 h-1 accent-teal-600"
+                            />
                         </div>
-                        <div className="mt-3 text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] flex items-center gap-1">
-                            <Info size={12} />
-                            {t('sl.theta_approx')}: {thetaFromHold(customHoldValue).toFixed(3)} (Keep E2)
-                        </div>
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400 pl-0.5">{t('sl.theta_approx')}: {thetaFromHold(customHoldValue).toFixed(3)} (Keep E2)</p>
                     </div>
                 )}
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 {(ester !== Ester.E2) && (
                     <div className={`space-y-2 ${(ester === Ester.EV && route === Route.sublingual) ? 'col-span-2' : ''}`}>
-                        <label className="block text-xs font-bold text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] uppercase tracking-wider">{t('field.dose_raw')}</label>
+                        <label className="block text-xs font-semibold text-gray-500 dark:text-gray-400 pl-1">{t('field.dose_raw')}</label>
                         <input
                             type="number" inputMode="decimal"
                             min="0"
                             step="0.001"
                             value={rawDose} onChange={e => onRawChange(e.target.value)}
-                            className="w-full p-4 bg-[var(--color-m3-surface-container)] dark:bg-[var(--color-m3-dark-surface-container-high)] border border-[var(--color-m3-outline-variant)] dark:border-[var(--color-m3-dark-outline-variant)] rounded-[var(--radius-lg)] focus:ring-2 focus:ring-[var(--color-m3-primary-container)] focus:border-[var(--color-m3-primary)] dark:focus:border-teal-400 outline-none font-mono text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] font-bold"
+                            className="w-full p-3 bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-xl focus:ring-1 focus:ring-teal-500 focus:border-teal-500 outline-none text-gray-900 dark:text-gray-100 font-medium text-sm transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                             placeholder="0.0"
                         />
                     </div>
@@ -152,7 +129,7 @@ const SublingualFields: React.FC<SublingualFieldsProps> = ({
 
                 {!(ester === Ester.EV && route === Route.sublingual) && ester !== Ester.CPA && (
                     <div className={`space-y-2 ${(ester === Ester.E2) ? "col-span-2" : ""}`}>
-                        <label className="block text-xs font-bold text-[var(--color-m3-accent)] uppercase tracking-wider">
+                        <label className="block text-xs font-semibold text-rose-500 dark:text-rose-400 pl-1">
                             {t('field.dose_e2')}
                         </label>
                         <input
@@ -160,7 +137,7 @@ const SublingualFields: React.FC<SublingualFieldsProps> = ({
                             min="0"
                             step="0.001"
                             value={e2Dose} onChange={e => onE2Change(e.target.value)}
-                            className="w-full p-4 bg-[var(--color-m3-accent-container)] dark:bg-rose-900/20 border border-[var(--color-m3-outline-variant)] dark:border-rose-900/30 rounded-[var(--radius-lg)] focus:ring-2 focus:ring-[var(--color-m3-accent)]/30 outline-none font-bold text-[var(--color-m3-accent)] dark:text-rose-400 font-mono"
+                            className="w-full p-3 bg-white dark:bg-neutral-900 border border-rose-200 dark:border-rose-900/50 rounded-xl focus:ring-1 focus:ring-rose-500 focus:border-rose-500 outline-none text-rose-600 dark:text-rose-400 font-medium text-sm transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                             placeholder="0.0"
                         />
                     </div>
@@ -168,7 +145,7 @@ const SublingualFields: React.FC<SublingualFieldsProps> = ({
 
                 {(ester === Ester.EV && route === Route.sublingual) && (
                     <div className="col-span-2">
-                        <p className="text-xs text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] mt-1">
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 pl-1">
                             {t('field.dose_e2')}: {e2Dose ? `${e2Dose} mg` : '--'}
                         </p>
                     </div>

--- a/src/contexts/DialogContext.tsx
+++ b/src/contexts/DialogContext.tsx
@@ -38,32 +38,27 @@ export const DialogProvider = ({ children }: { children: React.ReactNode }) => {
         <DialogContext.Provider value={{ showDialog }}>
             {children}
             {isOpen && (
-                <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-[100] p-6" style={{ animation: 'dialogFadeIn 0.18s ease-out forwards' }}>
-                    <style>{`
-                        @keyframes dialogFadeIn { from { opacity: 0; } to { opacity: 1; } }
-                        @keyframes dialogScaleIn { from { opacity: 0; transform: scale(0.92); } to { opacity: 1; transform: scale(1); } }
-                    `}</style>
-                    <div className="w-full max-w-sm">
+                <div className="fixed inset-0 bg-black/40 flex items-end md:items-center justify-center z-[100] p-0 md:p-4">
+                    <div className="w-full max-w-sm safe-area-pb">
                         <div
-                            className="bg-[var(--color-m3-surface-container-high)] dark:bg-[var(--color-m3-dark-surface-container-high)] rounded-[var(--radius-xl)] shadow-[var(--shadow-m3-3)] p-6 transform transition-all"
-                            style={{ animation: 'dialogScaleIn 0.2s ease-out forwards' }}
+                            className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-700 rounded-t-2xl md:rounded-xl shadow-lg p-5 max-h-[88vh] overflow-y-auto"
                         >
-                            <h3 className="font-display text-base font-bold text-[var(--color-m3-on-surface)] dark:text-[var(--color-m3-dark-on-surface)] mb-3 tracking-tight">
+                            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">
                                 {type === 'confirm' ? t('dialog.confirm_title') : t('dialog.alert_title')}
                             </h3>
-                            <p className="text-sm text-[var(--color-m3-on-surface-variant)] dark:text-[var(--color-m3-dark-on-surface-variant)] mb-6 leading-relaxed">{message}</p>
-                            <div className="flex justify-end gap-2">
+                            <p className="text-sm text-gray-600 dark:text-gray-300 mb-5 leading-relaxed">{message}</p>
+                            <div className="flex justify-end gap-2 pt-1">
                                 {type === 'confirm' && (
                                     <button
                                         onClick={() => setIsOpen(false)}
-                                        className="px-5 py-2.5 text-sm font-bold text-[var(--color-m3-primary)] dark:text-teal-400 rounded-[var(--radius-full)] hover:bg-[var(--color-m3-primary-container)]/40 dark:hover:bg-teal-900/20 transition-all"
+                                        className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-neutral-600 rounded-md"
                                     >
                                         {t('btn.cancel')}
                                     </button>
                                 )}
                                 <button
                                     onClick={handleConfirm}
-                                    className="px-5 py-2.5 text-sm font-bold bg-[var(--color-m3-primary)] dark:bg-teal-600 text-[var(--color-m3-on-primary)] rounded-[var(--radius-full)] hover:shadow-[var(--shadow-m3-1)] transition-all"
+                                    className="px-4 py-2 text-sm font-medium bg-teal-600 hover:bg-teal-700 text-white rounded-md"
                                 >
                                     {type === 'confirm' ? t('btn.ok') : t('btn.ok')}
                                 </button>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -26,7 +26,7 @@ export const TRANSLATIONS_BASE = {
         "chart.reset": "重置缩放",
 
         "label.e2": "雌二醇",
-        "label.cpa": "醋酸环丙孕酮",
+        "label.cpa": "CPA",
         "label.cpa_chart": "醋酸环丙孕酮",
         "label.e2_unit": "雌二醇 (pg/mL)",
         "label.cpa_unit": "醋酸环丙孕酮 (ng/mL)",
@@ -347,7 +347,7 @@ export const TRANSLATIONS_BASE = {
         "chart.reset": "Reset Zoom",
 
         "label.e2": "Estradiol",
-        "label.cpa": "Cyproterone Acetate",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "Estradiol (pg/mL)",
         "label.cpa_unit": "Cyproterone Acetate (ng/mL)",
@@ -666,7 +666,7 @@ export const TRANSLATIONS_BASE = {
         "chart.reset": "Сбросить масштаб",
 
         "label.e2": "Эстрадиол",
-        "label.cpa": "Ципротерон ацетат",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "Эстрадиол (pg/mL)",
         "label.cpa_unit": "Ципротерон ацетат (ng/mL)",
@@ -990,7 +990,7 @@ export const TRANSLATIONS = {
         "chart.reset": "重設縮放",
 
         "label.e2": "雌二醇",
-        "label.cpa": "醋酸環丙孕酮",
+        "label.cpa": "CPA",
         "label.cpa_chart": "醋酸環丙孕酮",
         "label.e2_unit": "雌二醇 (pg/mL)",
         "label.cpa_unit": "醋酸環丙孕酮 (ng/mL)",
@@ -1319,7 +1319,7 @@ export const TRANSLATIONS = {
         "chart.reset": "重置縮放",
 
         "label.e2": "雌二醇",
-        "label.cpa": "醋酸環丙孕酮",
+        "label.cpa": "CPA",
         "label.cpa_chart": "醋酸環丙孕酮",
         "label.e2_unit": "雌二醇 (pg/mL)",
         "label.cpa_unit": "醋酸環丙孕酮 (ng/mL)",
@@ -1589,7 +1589,7 @@ export const TRANSLATIONS = {
         "chart.reset": "Скинути масштаб",
 
         "label.e2": "Естрадіол",
-        "label.cpa": "Ципротерон ацетат",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "Естрадіол (pg/mL)",
         "label.cpa_unit": "Ципротерон ацетат (ng/mL)",
@@ -1909,7 +1909,7 @@ export const TRANSLATIONS = {
         "chart.reset": "ズームをリセット",
 
         "label.e2": "エストラジオール",
-        "label.cpa": "酢酸シプロテロン",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "エストラジオール (pg/mL)",
         "label.cpa_unit": "酢酸シプロテロン (ng/mL)",
@@ -2230,7 +2230,7 @@ export const TRANSLATIONS = {
         "chart.reset": "확대/축소 초기화",
 
         "label.e2": "에스트라디올",
-        "label.cpa": "사이프로테론 아세테이트",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "에스트라디올 (pg/mL)",
         "label.cpa_unit": "사이프로테론 아세테이트 (ng/mL)",
@@ -2549,7 +2549,7 @@ export const TRANSLATIONS = {
         "chart.reset": "إعادة تعيين التكبير",
 
         "label.e2": "الإستراديول",
-        "label.cpa": "سيبروتيرون أسيتات",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "الإستراديول (pg/mL)",
         "label.cpa_unit": "سيبروتيرون أسيتات (ng/mL)",
@@ -2868,7 +2868,7 @@ export const TRANSLATIONS = {
         "chart.reset": "איפוס זום",
 
         "label.e2": "אסטרדיול",
-        "label.cpa": "ציפרוטרון אצטט",
+        "label.cpa": "CPA",
         "label.cpa_chart": "CPA",
         "label.e2_unit": "אסטרדיול (pg/mL)",
         "label.cpa_unit": "ציפרוטרון אצטט (ng/mL)",

--- a/src/index.css
+++ b/src/index.css
@@ -70,7 +70,7 @@
     input:not([type="datetime-local"]):not([type="date"]):not([type="time"]):not([type="month"]):not([type="week"]):not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([type="file"]),
     select,
     textarea {
-        font-size: 16px;
+        font-size: 16px !important;
     }
 }
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -29,7 +29,7 @@ const Account: React.FC<AccountProps> = ({
     const [isDeleteAccountOpen, setIsDeleteAccountOpen] = useState(false);
 
     return (
-        <div className="relative space-y-5 pt-6 pb-24">
+        <div className="relative space-y-5 pt-6 pb-32">
             <div className="px-6 md:px-10">
                 <div className="w-full p-5 rounded-lg bg-white dark:bg-neutral-900 flex items-center justify-between border border-gray-200 dark:border-neutral-800 transition-all duration-300">
                     <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 tracking-tight flex items-center gap-3">

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -40,7 +40,7 @@ const History: React.FC<HistoryProps> = ({
     const [editingId, setEditingId] = useState<string | null>(null);
 
     return (
-        <div className="relative space-y-6 pt-6 pb-24">
+        <div className="relative space-y-6 pt-6 pb-32">
             <div className="px-6 md:px-8">
                 <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg flex items-center justify-between p-4 mb-6">
                     <div className="flex items-center gap-3">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -43,34 +43,35 @@ const Home: React.FC<HomeProps> = ({
                 <div className="flex flex-col gap-4">
 
                     {/* Main Estimate Card - Flat Design */}
-                    <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg p-5 md:p-6 flex flex-col justify-between">
+                    <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg p-4 md:p-5 flex flex-col justify-between">
 
                         {/* Status Header */}
-                        <div className="mb-6 flex items-center justify-between">
-                            <div className="flex items-center gap-3">
-                                <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                        <div className="mb-4 flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-2">
+                            <div className="flex items-center gap-2 min-w-0">
+                                <span className="text-sm font-medium text-gray-600 dark:text-gray-400 leading-tight">
                                     {t('status.estimate')}
                                 </span>
                                 <button
                                     onClick={() => setIsEstimateInfoOpen(true)}
-                                    className="flex items-center gap-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-xs transition-colors"
+                                    className="inline-flex items-center gap-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-xs transition-colors shrink-0"
+                                    title={t('status.read_me')}
                                 >
-                                    <Info size={14} />
-                                    {t('status.read_me')}
+                                    <Info size={13} />
+                                    <span className="hidden sm:inline">{t('status.read_me')}</span>
                                 </button>
                             </div>
                             {currentStatus && (
-                                <div className={`text-xs font-medium ${currentStatus.color}`}>
+                                <div className={`text-[11px] leading-tight text-left sm:text-right font-medium sm:max-w-[8.5rem] ${currentStatus.color}`}>
                                     {t(currentStatus.label)}
                                 </div>
                             )}
                         </div>
 
                         {/* Blood Levels Grid */}
-                        <div className="grid grid-cols-2 gap-6 uppercase tracking-wide">
+                        <div className="grid grid-cols-2 gap-4 uppercase tracking-wide">
                             {/* E2 Display */}
                             <div>
-                                <div className="text-xs font-semibold text-gray-500 dark:text-gray-500 mb-2">
+                                <div className="text-xs font-semibold text-gray-500 dark:text-gray-500 mb-1.5">
                                     {t('label.e2')}
                                 </div>
                                 <div className="flex items-baseline gap-1.5">
@@ -89,7 +90,7 @@ const Home: React.FC<HomeProps> = ({
 
                             {/* CPA Display */}
                             <div>
-                                <div className="text-xs font-semibold text-gray-500 dark:text-gray-500 mb-2">
+                                <div className="text-xs font-semibold text-gray-500 dark:text-gray-500 mb-1.5">
                                     {t('label.cpa')}
                                 </div>
                                 <div className="flex items-baseline gap-1.5">

--- a/src/pages/Lab.tsx
+++ b/src/pages/Lab.tsx
@@ -33,7 +33,7 @@ const Lab: React.FC<LabProps> = ({
     lang
 }) => {
     return (
-        <div className="relative space-y-6 pt-6 pb-24">
+        <div className="relative space-y-6 pt-6 pb-32">
             <div className="px-6 md:px-8">
                 <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg flex items-center justify-between p-4 mb-6">
                     <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -49,7 +49,7 @@ const Settings: React.FC<SettingsProps> = ({
     const hasExportData = events.length > 0 || labResults.length > 0;
 
     return (
-        <div className="relative space-y-6 pt-6 pb-24">
+        <div className="relative space-y-6 pt-6 pb-32">
             <div className="px-6 md:px-8">
                 <div className="bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg flex items-center justify-between p-4 mb-6">
                     <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">


### PR DESCRIPTION
Widespread UI/UX polish and small behavior improvements across components. Key changes: use 100dvh for App container to fix mobile height; CustomSelect now supports optional descriptions, truncation and fixes dropdown border/spacing; Disclaimer and Estimate modals redesigned to a bottom-sheet style with simplified visuals and updated button styling; DoseForm visual tweaks (badge colors, guide formatting), added template load/save/delete UI (menu moved to header), template delete confirmation, and external-link confirmation that opens links in a new tab; Export/Import inputs improved with autocomplete/autocorrect/autocapitalize/spellcheck attributes and a named password field; ResultChart gained fullscreen mode with maximize/minimize controls, orientation lock handling, Escape-to-close, viewport resize handling, body scroll lock while fullscreen, and responsive chart heights; plus various small styling, layout and accessibility refinements across pages and components.