### PR TITLE
Fix quick-add date defaulting to a stale time on History page

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -226,6 +226,8 @@ const History: React.FC<HistoryProps> = ({
                             </div>
                         )}
                         <DoseForm
+                            // Force remount on open so the default date resets to "now" (this row never unmounts, only collapses via CSS).
+                            key={isQuickAddOpen ? 'open' : 'closed'}
                             eventToEdit={null}
                             onSave={handleQuickSave}
                             onCancel={() => setIsQuickAddOpen(false)}


### PR DESCRIPTION
The inline quick-add DoseForm on the History page never unmounts
(only CSS-collapsed), so its "default to now" effect only ran once,
on first mount. Reopening the panel later in the same session kept
reusing that original timestamp instead of the current time, silently
mis-timestamping new records. Keying the form on open/close forces a
remount so the default resets to the actual current time each time.